### PR TITLE
Use endpoint class over Issuer class.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,13 @@ function checkDataIntegrityProofFormat({
         let data;
         before(async function() {
           const issuer = issuers.find(i => i.tags.has(tag));
-          const {issuer: {id: issuerId, options}} = issuer;
+          const {settings: {id: issuerId, options}} = issuer;
           const body = {credential: klona(validVc), options};
           // set a fresh id on the credential
           body.credential.id = `urn:uuid:${uuidv4()}`;
           // use the issuer's id for the issuer property
           body.credential.issuer = issuerId;
-          ({data} = await issuer.issue({body}));
+          ({data} = await issuer.post({json: body}));
           proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
         });
         it('`proof` field MUST exist at top-level of data object.', function() {

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -10,7 +10,7 @@ class MockIssuer {
   constructor({tags, mockVc}) {
     this._tags = tags;
     this._mockVc = mockVc;
-    this.issuer = {
+    this.settings = {
       id: 'did:issuer:foo',
       options: {
 
@@ -20,7 +20,7 @@ class MockIssuer {
   get tags() {
     return new Set(this._tags);
   }
-  async issue() {
+  async post() {
     return {data: this._mockVc};
   }
 }


### PR DESCRIPTION
https://github.com/w3c-ccg/vc-api-test-suite-implementations/pull/32

Replaces `issuer.issue` with `issuer.post`