### PR TITLE
Check if associated documents have expected contexts included.

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,19 +86,38 @@ export function checkDataIntegrityProofFormat({
               'string', 'Expected "proof.type" to be a string.');
           }
         });
-        it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}".`,
-          function() {
-            this.test.cell = {columnId: vendorName, rowId: this.test.title};
-            for(const proof of proofs) {
-              proof.should.have.property('type');
-              proof.type.should.be.a(
-                'string',
-                'Expected "proof.type" to be a string.'
-              );
-              const hasExpectedType = expectedProofTypes.includes(proof.type);
-              hasExpectedType.should.equal(true);
+        it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
+          `and the associated document MUST include expected contexts.`,
+        function() {
+          this.test.cell = {columnId: vendorName, rowId: this.test.title};
+          for(const proof of proofs) {
+            proof.should.have.property('type');
+            proof.type.should.be.a(
+              'string',
+              'Expected "proof.type" to be a string.'
+            );
+            const hasExpectedType = expectedProofTypes.includes(proof.type);
+            hasExpectedType.should.equal(true);
+
+            if(proof.type === 'DataIntegrityProof') {
+              const expectedContexts = [
+                'https://www.w3.org/ns/credentials/v2',
+                'https://w3id.org/security/data-integrity/v2'
+              ];
+              const hasExpectedContexts = expectedContexts.some(
+                value => data['@context'].includes(value));
+              hasExpectedContexts.should.equal(true);
             }
-          });
+
+            if(proof.type === 'Ed25519Signature2020') {
+              const expectedContext =
+                'https://w3id.org/security/suites/ed25519-2020/v1';
+              const hasExpectedContext =
+                data['@context'].includes(expectedContext);
+              hasExpectedContext.should.equal(true);
+            }
+          }
+        });
         if(expectedCryptoSuite) {
           it('"proof.cryptosuite" field MUST exist and be a string.',
             function() {

--- a/issuedVc.js
+++ b/issuedVc.js
@@ -3,15 +3,15 @@
  */
 export const issuedVc = {
   '@context': [
-    'https://www.w3.org/2018/credentials/v1',
-    'https://w3id.org/security/data-integrity/v1'
+    'https://www.w3.org/ns/credentials/v2',
+    'https://w3id.org/security/data-integrity/v2'
   ],
   id: 'urn:uuid:cb6a2b0b-a749-40dc-9ce2-dd3d938508fc',
   type: [
     'VerifiableCredential'
   ],
   issuer: 'did:key:z6MkiimK73pVRzGLpj869NybZQqPTGGogmdPMmBaAHJF4uZD',
-  issuanceDate: '2020-03-16T22:37:26.544Z',
+  validFrom: '2020-03-16T22:37:26.544Z',
   credentialSubject: {
     id: 'did:key:z6MktKwz7Ge1Yxzr4JHavN33wiwa8y81QdcMRLXQsrH9T53b'
   },


### PR DESCRIPTION
Addresses https://github.com/w3c-ccg/data-integrity-test-suite-assertion/issues/18#issuecomment-1787883656.  The proof type was already being checked so I just updated the existing test to also check for the expected contexts.

This PR will close issues #18 and #19 