### PR TITLE
Pin node to v20.8.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.8.0]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.8.0]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Node versions > v20.8.0 introduced a bug in how HTTP headers are exposed within node causing these tests to fail. Pinning the node version until that is fixed 
should allow us to keep tests working in the meantime.﻿
