### PR TITLE
Add `isEcdsaTests` option to `checkDataIntegrityProofFormat()` and `checkDataIntegrityProofVerifyErrors()`

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -80,10 +80,10 @@ export function isStringOrArrayOfStrings(data) {
   return typeof data === 'string';
 }
 
-export function getKeyType(tags) {
+export function getKeyType(supportedEcdsaKeyTypes) {
   const supportedKeyTypes = ['P-256', 'P-384'];
   for(const keyType of supportedKeyTypes) {
-    if(tags.includes(keyType)) {
+    if(supportedEcdsaKeyTypes.includes(keyType)) {
       return keyType;
     }
   }

--- a/helpers.js
+++ b/helpers.js
@@ -79,3 +79,13 @@ export function isStringOrArrayOfStrings(data) {
   }
   return typeof data === 'string';
 }
+
+export function getKeyType(tags) {
+  const supportedKeyTypes = ['P-256', 'P-384'];
+  for(const keyType of supportedKeyTypes) {
+    if(tags.includes(keyType)) {
+      return keyType;
+    }
+  }
+  return null;
+}

--- a/helpers.js
+++ b/helpers.js
@@ -80,12 +80,10 @@ export function isStringOrArrayOfStrings(data) {
   return typeof data === 'string';
 }
 
-export function getKeyType(supportedEcdsaKeyTypes) {
+export function checkKeyType(keyType) {
   const supportedKeyTypes = ['P-256', 'P-384'];
-  for(const keyType of supportedKeyTypes) {
-    if(supportedEcdsaKeyTypes.includes(keyType)) {
-      return keyType;
-    }
+  if(supportedKeyTypes.includes(keyType)) {
+    return keyType;
   }
-  return null;
+  throw new Error(`Unsupported ECDSA key type: ${keyType}.`);
 }

--- a/index.js
+++ b/index.js
@@ -37,19 +37,11 @@ export function checkDataIntegrityProofFormat({
     this.matrix = true;
     this.report = true;
     if(isEcdsaTests) {
-      const names = [...implemented.keys()];
       this.implemented = [];
-      for(const name of names) {
-        const {endpoints} = implemented.get(name);
-        if(endpoints.length > 1) {
-          for(const endpoint of endpoints) {
-            const {tags} = endpoint.settings;
-            const keyType = getKeyType(tags);
-            this.implemented.push(`${name}: ${keyType}`);
-          }
-        } else {
-          const {tags} = endpoints[0].settings;
-          const keyType = getKeyType(tags);
+      for(const [name, {endpoints}] of implemented) {
+        for(const endpoint of endpoints) {
+          const {supportedEcdsaKeyTypes} = endpoint.settings;
+          const keyType = getKeyType(supportedEcdsaKeyTypes);
           this.implemented.push(`${name}: ${keyType}`);
         }
       }
@@ -65,8 +57,8 @@ export function checkDataIntegrityProofFormat({
       for(const endpoint of endpoints) {
         let testDescription;
         if(isEcdsaTests) {
-          const tags = endpoint.settings.tags;
-          const keyType = getKeyType(tags);
+          const {supportedEcdsaKeyTypes} = endpoint.settings;
+          const keyType = getKeyType(supportedEcdsaKeyTypes);
           testDescription = `${vendorName}: ${keyType}`;
         } else {
           testDescription = vendorName;

--- a/index.js
+++ b/index.js
@@ -308,23 +308,18 @@ export function checkDataIntegrityProofVerifyErrors({
         throw new Error(`Expected ${vendorName} to have endpoints.`);
       }
       for(const endpoint of endpoints) {
+        let name;
         if(isEcdsaTests) {
           const {supportedEcdsaKeyTypes} = endpoint.settings;
-          for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
-            const keyType = checkKeyType(supportedEcdsaKeyType);
-            this.implemented.push(`${vendorName}: ${keyType}`);
-            runDataIntegrityProofVerifyTests({
-              endpoints, expectedProofType,
-              testDescription: `${vendorName}: ${keyType}`, vendorName
-            });
-          }
+          const keyTypes = supportedEcdsaKeyTypes.join(', ');
+          name = `${vendorName}: ${keyTypes}`;
         } else {
-          this.implemented.push(vendorName);
-          runDataIntegrityProofVerifyTests({
-            endpoints, expectedProofType, testDescription: vendorName,
-            vendorName
-          });
+          name = vendorName;
         }
+        this.implemented.push(name);
+        runDataIntegrityProofVerifyTests({
+          endpoints, expectedProofType, testDescription: name, vendorName
+        });
       }
     } // end for loop
   }); // end describe

--- a/index.js
+++ b/index.js
@@ -62,209 +62,221 @@ export function checkDataIntegrityProofFormat({
       if(!endpoints) {
         throw new Error(`Expected ${vendorName} to have endpoints.`);
       }
-      describe(vendorName, function() {
-        let proofs = [];
-        let data;
-        before(async function() {
-          const [issuer] = endpoints;
-          if(!issuer) {
-            throw new Error(`Expected ${vendorName} to have an issuer.`);
-          }
-          data = await createInitialVc({issuer, vc: validVc});
-          proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
-        });
-        it('"proof" field MUST exist and MUST be either a single object or ' +
-          'an unordered set of objects.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          should.exist(data, 'Expected data.');
-          const proof = data.proof;
-          should.exist(proof, 'Expected proof to exist.');
-          const validType = isObjectOrArrayOfObjects(proof);
-          validType.should.equal(true, 'Expected proof to be' +
-            'either an object or an unordered set of objects.');
-        });
-        it('if "proof.id" field exists, it MUST be a valid URL.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            if(proof.id) {
-              let result;
-              let err;
-              try {
-                result = new URL(proof.id);
-              } catch(e) {
-                err = e;
+      for(const endpoint of endpoints) {
+        let testDescription;
+        if(isEcdsaTests) {
+          const tags = endpoint.settings.tags;
+          const keyType = getKeyType(tags);
+          testDescription = `${vendorName}: ${keyType}`;
+        } else {
+          testDescription = vendorName;
+        }
+        const columnId = testDescription;
+        describe(testDescription, function() {
+          let proofs = [];
+          let data;
+          before(async function() {
+            const [issuer] = endpoints;
+            if(!issuer) {
+              throw new Error(`Expected ${vendorName} to have an issuer.`);
+            }
+            data = await createInitialVc({issuer, vc: validVc});
+            proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
+          });
+          it('"proof" field MUST exist and MUST be either a single object or ' +
+            'an unordered set of objects.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            should.exist(data, 'Expected data.');
+            const proof = data.proof;
+            should.exist(proof, 'Expected proof to exist.');
+            const validType = isObjectOrArrayOfObjects(proof);
+            validType.should.equal(true, 'Expected proof to be' +
+              'either an object or an unordered set of objects.');
+          });
+          it('if "proof.id" field exists, it MUST be a valid URL.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            for(const proof of proofs) {
+              if(proof.id) {
+                let result;
+                let err;
+                try {
+                  result = new URL(proof.id);
+                } catch(e) {
+                  err = e;
+                }
+                should.not.exist(err, 'Expected URL check of the "proof.id" ' +
+                  'to not error.');
+                should.exist(result, 'Expected "proof.id" to be a URL.');
               }
-              should.not.exist(err, 'Expected URL check of the "proof.id" ' +
-                'to not error.');
-              should.exist(result, 'Expected "proof.id" to be a URL.');
             }
-          }
-        });
-        it('"proof.type" field MUST exist and be a string.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            proof.should.have.property('type');
-            proof.type.should.be.a(
-              'string', 'Expected "proof.type" to be a string.');
-          }
-        });
-        it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
-          `and the associated document MUST include expected contexts.`,
-        function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            proof.should.have.property('type');
-            proof.type.should.be.a(
-              'string',
-              'Expected "proof.type" to be a string.'
-            );
-            const hasExpectedType = expectedProofTypes.includes(proof.type);
-            hasExpectedType.should.equal(true);
+          });
+          it('"proof.type" field MUST exist and be a string.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            for(const proof of proofs) {
+              proof.should.have.property('type');
+              proof.type.should.be.a(
+                'string', 'Expected "proof.type" to be a string.');
+            }
+          });
+          it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
+            `and the associated document MUST include expected contexts.`,
+          function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            for(const proof of proofs) {
+              proof.should.have.property('type');
+              proof.type.should.be.a(
+                'string',
+                'Expected "proof.type" to be a string.'
+              );
+              const hasExpectedType = expectedProofTypes.includes(proof.type);
+              hasExpectedType.should.equal(true);
 
-            if(proof.type === 'DataIntegrityProof') {
-              const expectedContexts = [
-                'https://www.w3.org/ns/credentials/v2',
-                'https://w3id.org/security/data-integrity/v2'
-              ];
-              const hasExpectedContexts = expectedContexts.some(
-                value => data['@context'].includes(value));
-              hasExpectedContexts.should.equal(true);
-            }
+              if(proof.type === 'DataIntegrityProof') {
+                const expectedContexts = [
+                  'https://www.w3.org/ns/credentials/v2',
+                  'https://w3id.org/security/data-integrity/v2'
+                ];
+                const hasExpectedContexts = expectedContexts.some(
+                  value => data['@context'].includes(value));
+                hasExpectedContexts.should.equal(true);
+              }
 
-            if(proof.type === 'Ed25519Signature2020') {
-              const expectedContext =
-                'https://w3id.org/security/suites/ed25519-2020/v1';
-              const hasExpectedContext =
-                data['@context'].includes(expectedContext);
-              hasExpectedContext.should.equal(true);
+              if(proof.type === 'Ed25519Signature2020') {
+                const expectedContext =
+                  'https://w3id.org/security/suites/ed25519-2020/v1';
+                const hasExpectedContext =
+                  data['@context'].includes(expectedContext);
+                hasExpectedContext.should.equal(true);
+              }
             }
+          });
+          if(expectedCryptoSuite) {
+            it('"proof.cryptosuite" field MUST exist and be a string.',
+              function() {
+                this.test.cell = {columnId, rowId: this.test.title};
+                for(const proof of proofs) {
+                  proof.should.have.property('cryptosuite');
+                  proof.cryptosuite.should.be.a('string', 'Expected ' +
+                    '"cryptosuite" property to be a string.');
+                }
+              });
           }
-        });
-        if(expectedCryptoSuite) {
-          it('"proof.cryptosuite" field MUST exist and be a string.',
+          it('if "proof.created" field exists, it MUST be a valid ' +
+            'XMLSCHEMA-11 dateTimeStamp value.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            for(const proof of proofs) {
+              if(proof.created) {
+                // check if "created" is a valid XML Schema 1.1 dateTimeStamp
+                // value
+                proof.created.should.match(dateRegex);
+              }
+            }
+          });
+          it('if "proof.expires" field exists, it MUST be a valid ' +
+            'XMLSCHEMA-11 dateTimeStamp value.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            for(const proof of proofs) {
+              if(proof.expires) {
+                // check if "created" is a valid XML Schema 1.1 dateTimeStamp
+                // value
+                proof.expires.should.match(dateRegex);
+              }
+            }
+          });
+          it('"proof.verificationMethod" field MUST exist and be a valid URL.',
             function() {
-              this.test.cell = {columnId: vendorName, rowId: this.test.title};
+              this.test.cell = {columnId, rowId: this.test.title};
               for(const proof of proofs) {
-                proof.should.have.property('cryptosuite');
-                proof.cryptosuite.should.be.a('string', 'Expected ' +
-                  '"cryptosuite" property to be a string.');
+                proof.should.have.property('verificationMethod');
+                let result;
+                let err;
+                try {
+                  result = new URL(proof.verificationMethod);
+                } catch(e) {
+                  err = e;
+                }
+                should.not.exist(err, 'Expected URL check of the ' +
+                  '"verificationMethod" to not error.');
+                should.exist(result, 'Expected "verificationMethod" ' +
+                  'to be a URL');
               }
             });
-        }
-        it('if "proof.created" field exists, it MUST be a valid XMLSCHEMA-11 ' +
-          'dateTimeStamp value.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            if(proof.created) {
-              // check if "created" is a valid XML Schema 1.1 dateTimeStamp
-              // value
-              proof.created.should.match(dateRegex);
-            }
-          }
-        });
-        it('if "proof.expires" field exists, it MUST be a valid XMLSCHEMA-11 ' +
-          'dateTimeStamp value.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            if(proof.expires) {
-              // check if "created" is a valid XML Schema 1.1 dateTimeStamp
-              // value
-              proof.expires.should.match(dateRegex);
-            }
-          }
-        });
-        it('"proof.verificationMethod" field MUST exist and be a valid URL.',
-          function() {
-            this.test.cell = {columnId: vendorName, rowId: this.test.title};
-            for(const proof of proofs) {
-              proof.should.have.property('verificationMethod');
-              let result;
-              let err;
-              try {
-                result = new URL(proof.verificationMethod);
-              } catch(e) {
-                err = e;
+          it('"proof.proofPurpose" field MUST exist and be a string.',
+            function() {
+              this.test.cell = {columnId, rowId: this.test.title};
+              for(const proof of proofs) {
+                proof.should.have.property('proofPurpose');
+                proof.proofPurpose.should.be.a('string');
               }
-              should.not.exist(err, 'Expected URL check of the ' +
-                '"verificationMethod" to not error.');
-              should.exist(result, 'Expected "verificationMethod" ' +
-                'to be a URL');
-            }
+            });
+          it('"proof.proofValue" field MUST exist and be a string.',
+            function() {
+              this.test.cell = {columnId, rowId: this.test.title};
+              for(const proof of proofs) {
+                proof.should.have.property('proofValue');
+                proof.proofValue.should.be.a('string');
+              }
+            });
+          it('The "proof.proofValue" field MUST be a multibase-encoded ' +
+            'base58-btc encoded value.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
+            const multibase = 'z';
+            proofs.some(proof => {
+              const value = proof?.proofValue;
+              return value.startsWith(multibase) && shouldBeBs58(value);
+            }).should.equal(
+              true,
+              'Expected "proof.proofValue" to be multibase-encoded ' +
+              'base58-btc value.'
+            );
           });
-        it('"proof.proofPurpose" field MUST exist and be a string.',
-          function() {
-            this.test.cell = {columnId: vendorName, rowId: this.test.title};
+          it('if "proof.domain" field exists, it MUST be either a string, ' +
+            'or an unordered set of strings.', function() {
+            this.test.cell = {columnId, rowId: this.test.title};
             for(const proof of proofs) {
-              proof.should.have.property('proofPurpose');
-              proof.proofPurpose.should.be.a('string');
-            }
-          });
-        it('"proof.proofValue" field MUST exist and be a string.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            proof.should.have.property('proofValue');
-            proof.proofValue.should.be.a('string');
-          }
-        });
-        it('The "proof.proofValue" field MUST be a multibase-encoded ' +
-          'base58-btc encoded value.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          const multibase = 'z';
-          proofs.some(proof => {
-            const value = proof?.proofValue;
-            return value.startsWith(multibase) && shouldBeBs58(value);
-          }).should.equal(
-            true,
-            'Expected "proof.proofValue" to be multibase-encoded base58-btc ' +
-            'value.'
-          );
-        });
-        it('if "proof.domain" field exists, it MUST be either a string, ' +
-          'or an unordered set of strings.', function() {
-          this.test.cell = {columnId: vendorName, rowId: this.test.title};
-          for(const proof of proofs) {
-            if(proof.domain) {
-              const validType = isStringOrArrayOfStrings(proof.domain);
-              validType.should.equal(true, 'Expected ' +
-                '"proof.domain" to be either a string or an unordered ' +
-                'set of strings.');
-            }
-          }
-        });
-        it('if "proof.challenge" field exists, it MUST be a string.',
-          function() {
-            this.test.cell = {columnId: vendorName, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.challenge) {
-                // domain must be specified
-                should.exist(proof.domain, 'Expected "proof.domain" ' +
-                  'to be specified.');
-                proof.challenge.should.be.a('string', 'Expected ' +
-                  '"proof.challenge" to be a string.');
+              if(proof.domain) {
+                const validType = isStringOrArrayOfStrings(proof.domain);
+                validType.should.equal(true, 'Expected ' +
+                  '"proof.domain" to be either a string or an unordered ' +
+                  'set of strings.');
               }
             }
           });
-        it('if "proof.previousProof" field exists, it MUST be a string.',
-          function() {
-            this.test.cell = {columnId: vendorName, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.previousProof) {
-                proof.previousProof.should.be.a('string', 'Expected ' +
-                  '"proof.previousProof" to be a string.');
+          it('if "proof.challenge" field exists, it MUST be a string.',
+            function() {
+              this.test.cell = {columnId, rowId: this.test.title};
+              for(const proof of proofs) {
+                if(proof.challenge) {
+                  // domain must be specified
+                  should.exist(proof.domain, 'Expected "proof.domain" ' +
+                    'to be specified.');
+                  proof.challenge.should.be.a('string', 'Expected ' +
+                    '"proof.challenge" to be a string.');
+                }
               }
-            }
-          });
-        it('if "proof.nonce" field exists, it MUST be a string.',
-          function() {
-            this.test.cell = {columnId: vendorName, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.nonce) {
-                proof.nonce.should.be.a('string', 'Expected "proof.nonce" ' +
-                  'to be a string.');
+            });
+          it('if "proof.previousProof" field exists, it MUST be a string.',
+            function() {
+              this.test.cell = {columnId, rowId: this.test.title};
+              for(const proof of proofs) {
+                if(proof.previousProof) {
+                  proof.previousProof.should.be.a('string', 'Expected ' +
+                    '"proof.previousProof" to be a string.');
+                }
               }
-            }
-          });
-      });
+            });
+          it('if "proof.nonce" field exists, it MUST be a string.',
+            function() {
+              this.test.cell = {columnId, rowId: this.test.title};
+              for(const proof of proofs) {
+                if(proof.nonce) {
+                  proof.nonce.should.be.a('string', 'Expected "proof.nonce" ' +
+                    'to be a string.');
+                }
+              }
+            });
+        });
+      }
     } // end for loop
   }); // end describe
 }

--- a/index.js
+++ b/index.js
@@ -36,237 +36,248 @@ export function checkDataIntegrityProofFormat({
     // to make an interop matrix with this suite
     this.matrix = true;
     this.report = true;
+    this.rowLabel = 'Test Name';
+    this.columnLabel = 'Issuer';
     if(isEcdsaTests) {
       this.implemented = [];
     } else {
       this.implemented = [...implemented.keys()];
     }
-    this.rowLabel = 'Test Name';
-    this.columnLabel = 'Issuer';
     for(const [vendorName, {endpoints}] of implemented) {
       if(!endpoints) {
         throw new Error(`Expected ${vendorName} to have endpoints.`);
       }
       for(const endpoint of endpoints) {
-        let testDescription;
         if(isEcdsaTests) {
           const {supportedEcdsaKeyTypes} = endpoint.settings;
           for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
             const keyType = checkKeyType(supportedEcdsaKeyType);
             this.implemented.push(`${vendorName}: ${keyType}`);
-            testDescription = `${vendorName}: ${keyType}`;
+            runDataIntegrityProofFormatTests({
+              endpoints, expectedCryptoSuite, expectedProofTypes,
+              testDescription: `${vendorName}: ${keyType}`, vendorName
+            });
           }
         } else {
-          testDescription = vendorName;
+          runDataIntegrityProofFormatTests({
+            endpoints, expectedCryptoSuite, expectedProofTypes,
+            testDescription: vendorName, vendorName
+          });
         }
-        const columnId = testDescription;
-        describe(testDescription, function() {
-          let proofs = [];
-          let data;
-          before(async function() {
-            const [issuer] = endpoints;
-            if(!issuer) {
-              throw new Error(`Expected ${vendorName} to have an issuer.`);
-            }
-            data = await createInitialVc({issuer, vc: validVc});
-            proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
-          });
-          it('"proof" field MUST exist and MUST be either a single object or ' +
-            'an unordered set of objects.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            should.exist(data, 'Expected data.');
-            const proof = data.proof;
-            should.exist(proof, 'Expected proof to exist.');
-            const validType = isObjectOrArrayOfObjects(proof);
-            validType.should.equal(true, 'Expected proof to be' +
-              'either an object or an unordered set of objects.');
-          });
-          it('if "proof.id" field exists, it MUST be a valid URL.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.id) {
-                let result;
-                let err;
-                try {
-                  result = new URL(proof.id);
-                } catch(e) {
-                  err = e;
-                }
-                should.not.exist(err, 'Expected URL check of the "proof.id" ' +
-                  'to not error.');
-                should.exist(result, 'Expected "proof.id" to be a URL.');
-              }
-            }
-          });
-          it('"proof.type" field MUST exist and be a string.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            for(const proof of proofs) {
-              proof.should.have.property('type');
-              proof.type.should.be.a(
-                'string', 'Expected "proof.type" to be a string.');
-            }
-          });
-          it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
-            `and the associated document MUST include expected contexts.`,
-          function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            for(const proof of proofs) {
-              proof.should.have.property('type');
-              proof.type.should.be.a(
-                'string',
-                'Expected "proof.type" to be a string.'
-              );
-              const hasExpectedType = expectedProofTypes.includes(proof.type);
-              hasExpectedType.should.equal(true);
-
-              if(proof.type === 'DataIntegrityProof') {
-                const expectedContexts = [
-                  'https://www.w3.org/ns/credentials/v2',
-                  'https://w3id.org/security/data-integrity/v2'
-                ];
-                const hasExpectedContexts = expectedContexts.some(
-                  value => data['@context'].includes(value));
-                hasExpectedContexts.should.equal(true);
-              }
-
-              if(proof.type === 'Ed25519Signature2020') {
-                const expectedContext =
-                  'https://w3id.org/security/suites/ed25519-2020/v1';
-                const hasExpectedContext =
-                  data['@context'].includes(expectedContext);
-                hasExpectedContext.should.equal(true);
-              }
-            }
-          });
-          if(expectedCryptoSuite) {
-            it('"proof.cryptosuite" field MUST exist and be a string.',
-              function() {
-                this.test.cell = {columnId, rowId: this.test.title};
-                for(const proof of proofs) {
-                  proof.should.have.property('cryptosuite');
-                  proof.cryptosuite.should.be.a('string', 'Expected ' +
-                    '"cryptosuite" property to be a string.');
-                }
-              });
-          }
-          it('if "proof.created" field exists, it MUST be a valid ' +
-            'XMLSCHEMA-11 dateTimeStamp value.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.created) {
-                // check if "created" is a valid XML Schema 1.1 dateTimeStamp
-                // value
-                proof.created.should.match(dateRegex);
-              }
-            }
-          });
-          it('if "proof.expires" field exists, it MUST be a valid ' +
-            'XMLSCHEMA-11 dateTimeStamp value.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.expires) {
-                // check if "created" is a valid XML Schema 1.1 dateTimeStamp
-                // value
-                proof.expires.should.match(dateRegex);
-              }
-            }
-          });
-          it('"proof.verificationMethod" field MUST exist and be a valid URL.',
-            function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              for(const proof of proofs) {
-                proof.should.have.property('verificationMethod');
-                let result;
-                let err;
-                try {
-                  result = new URL(proof.verificationMethod);
-                } catch(e) {
-                  err = e;
-                }
-                should.not.exist(err, 'Expected URL check of the ' +
-                  '"verificationMethod" to not error.');
-                should.exist(result, 'Expected "verificationMethod" ' +
-                  'to be a URL');
-              }
-            });
-          it('"proof.proofPurpose" field MUST exist and be a string.',
-            function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              for(const proof of proofs) {
-                proof.should.have.property('proofPurpose');
-                proof.proofPurpose.should.be.a('string');
-              }
-            });
-          it('"proof.proofValue" field MUST exist and be a string.',
-            function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              for(const proof of proofs) {
-                proof.should.have.property('proofValue');
-                proof.proofValue.should.be.a('string');
-              }
-            });
-          it('The "proof.proofValue" field MUST be a multibase-encoded ' +
-            'base58-btc encoded value.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const multibase = 'z';
-            proofs.some(proof => {
-              const value = proof?.proofValue;
-              return value.startsWith(multibase) && shouldBeBs58(value);
-            }).should.equal(
-              true,
-              'Expected "proof.proofValue" to be multibase-encoded ' +
-              'base58-btc value.'
-            );
-          });
-          it('if "proof.domain" field exists, it MUST be either a string, ' +
-            'or an unordered set of strings.', function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            for(const proof of proofs) {
-              if(proof.domain) {
-                const validType = isStringOrArrayOfStrings(proof.domain);
-                validType.should.equal(true, 'Expected ' +
-                  '"proof.domain" to be either a string or an unordered ' +
-                  'set of strings.');
-              }
-            }
-          });
-          it('if "proof.challenge" field exists, it MUST be a string.',
-            function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              for(const proof of proofs) {
-                if(proof.challenge) {
-                  // domain must be specified
-                  should.exist(proof.domain, 'Expected "proof.domain" ' +
-                    'to be specified.');
-                  proof.challenge.should.be.a('string', 'Expected ' +
-                    '"proof.challenge" to be a string.');
-                }
-              }
-            });
-          it('if "proof.previousProof" field exists, it MUST be a string.',
-            function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              for(const proof of proofs) {
-                if(proof.previousProof) {
-                  proof.previousProof.should.be.a('string', 'Expected ' +
-                    '"proof.previousProof" to be a string.');
-                }
-              }
-            });
-          it('if "proof.nonce" field exists, it MUST be a string.',
-            function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              for(const proof of proofs) {
-                if(proof.nonce) {
-                  proof.nonce.should.be.a('string', 'Expected "proof.nonce" ' +
-                    'to be a string.');
-                }
-              }
-            });
-        });
       }
     } // end for loop
   }); // end describe
+}
+
+function runDataIntegrityProofFormatTests({
+  endpoints, expectedCryptoSuite, expectedProofTypes, testDescription,
+  vendorName
+}) {
+  describe(testDescription, function() {
+    const columnId = testDescription;
+    let proofs = [];
+    let data;
+    before(async function() {
+      const [issuer] = endpoints;
+      if(!issuer) {
+        throw new Error(`Expected ${vendorName} to have an issuer.`);
+      }
+      data = await createInitialVc({issuer, vc: validVc});
+      proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
+    });
+    it('"proof" field MUST exist and MUST be either a single object or ' +
+        'an unordered set of objects.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      should.exist(data, 'Expected data.');
+      const proof = data.proof;
+      should.exist(proof, 'Expected proof to exist.');
+      const validType = isObjectOrArrayOfObjects(proof);
+      validType.should.equal(true, 'Expected proof to be' +
+          'either an object or an unordered set of objects.');
+    });
+    it('if "proof.id" field exists, it MUST be a valid URL.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      for(const proof of proofs) {
+        if(proof.id) {
+          let result;
+          let err;
+          try {
+            result = new URL(proof.id);
+          } catch(e) {
+            err = e;
+          }
+          should.not.exist(err, 'Expected URL check of the "proof.id" ' +
+              'to not error.');
+          should.exist(result, 'Expected "proof.id" to be a URL.');
+        }
+      }
+    });
+    it('"proof.type" field MUST exist and be a string.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      for(const proof of proofs) {
+        proof.should.have.property('type');
+        proof.type.should.be.a(
+          'string', 'Expected "proof.type" to be a string.');
+      }
+    });
+    it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
+        `and the associated document MUST include expected contexts.`,
+    function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      for(const proof of proofs) {
+        proof.should.have.property('type');
+        proof.type.should.be.a(
+          'string',
+          'Expected "proof.type" to be a string.'
+        );
+        const hasExpectedType = expectedProofTypes.includes(proof.type);
+        hasExpectedType.should.equal(true);
+
+        if(proof.type === 'DataIntegrityProof') {
+          const expectedContexts = [
+            'https://www.w3.org/ns/credentials/v2',
+            'https://w3id.org/security/data-integrity/v2'
+          ];
+          const hasExpectedContexts = expectedContexts.some(
+            value => data['@context'].includes(value));
+          hasExpectedContexts.should.equal(true);
+        }
+
+        if(proof.type === 'Ed25519Signature2020') {
+          const expectedContext =
+              'https://w3id.org/security/suites/ed25519-2020/v1';
+          const hasExpectedContext =
+              data['@context'].includes(expectedContext);
+          hasExpectedContext.should.equal(true);
+        }
+      }
+    });
+    if(expectedCryptoSuite) {
+      it('"proof.cryptosuite" field MUST exist and be a string.',
+        function() {
+          this.test.cell = {columnId, rowId: this.test.title};
+          for(const proof of proofs) {
+            proof.should.have.property('cryptosuite');
+            proof.cryptosuite.should.be.a('string', 'Expected ' +
+                '"cryptosuite" property to be a string.');
+          }
+        });
+    }
+    it('if "proof.created" field exists, it MUST be a valid ' +
+        'XMLSCHEMA-11 dateTimeStamp value.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      for(const proof of proofs) {
+        if(proof.created) {
+          // check if "created" is a valid XML Schema 1.1 dateTimeStamp
+          // value
+          proof.created.should.match(dateRegex);
+        }
+      }
+    });
+    it('if "proof.expires" field exists, it MUST be a valid ' +
+        'XMLSCHEMA-11 dateTimeStamp value.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      for(const proof of proofs) {
+        if(proof.expires) {
+          // check if "created" is a valid XML Schema 1.1 dateTimeStamp
+          // value
+          proof.expires.should.match(dateRegex);
+        }
+      }
+    });
+    it('"proof.verificationMethod" field MUST exist and be a valid URL.',
+      function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        for(const proof of proofs) {
+          proof.should.have.property('verificationMethod');
+          let result;
+          let err;
+          try {
+            result = new URL(proof.verificationMethod);
+          } catch(e) {
+            err = e;
+          }
+          should.not.exist(err, 'Expected URL check of the ' +
+              '"verificationMethod" to not error.');
+          should.exist(result, 'Expected "verificationMethod" ' +
+              'to be a URL');
+        }
+      });
+    it('"proof.proofPurpose" field MUST exist and be a string.',
+      function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        for(const proof of proofs) {
+          proof.should.have.property('proofPurpose');
+          proof.proofPurpose.should.be.a('string');
+        }
+      });
+    it('"proof.proofValue" field MUST exist and be a string.',
+      function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        for(const proof of proofs) {
+          proof.should.have.property('proofValue');
+          proof.proofValue.should.be.a('string');
+        }
+      });
+    it('The "proof.proofValue" field MUST be a multibase-encoded ' +
+        'base58-btc encoded value.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const multibase = 'z';
+      proofs.some(proof => {
+        const value = proof?.proofValue;
+        return value.startsWith(multibase) && shouldBeBs58(value);
+      }).should.equal(
+        true,
+        'Expected "proof.proofValue" to be multibase-encoded ' +
+          'base58-btc value.'
+      );
+    });
+    it('if "proof.domain" field exists, it MUST be either a string, ' +
+        'or an unordered set of strings.', function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      for(const proof of proofs) {
+        if(proof.domain) {
+          const validType = isStringOrArrayOfStrings(proof.domain);
+          validType.should.equal(true, 'Expected ' +
+              '"proof.domain" to be either a string or an unordered ' +
+              'set of strings.');
+        }
+      }
+    });
+    it('if "proof.challenge" field exists, it MUST be a string.',
+      function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        for(const proof of proofs) {
+          if(proof.challenge) {
+            // domain must be specified
+            should.exist(proof.domain, 'Expected "proof.domain" ' +
+                'to be specified.');
+            proof.challenge.should.be.a('string', 'Expected ' +
+                '"proof.challenge" to be a string.');
+          }
+        }
+      });
+    it('if "proof.previousProof" field exists, it MUST be a string.',
+      function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        for(const proof of proofs) {
+          if(proof.previousProof) {
+            proof.previousProof.should.be.a('string', 'Expected ' +
+                '"proof.previousProof" to be a string.');
+          }
+        }
+      });
+    it('if "proof.nonce" field exists, it MUST be a string.',
+      function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        for(const proof of proofs) {
+          if(proof.nonce) {
+            proof.nonce.should.be.a('string', 'Expected "proof.nonce" ' +
+                'to be a string.');
+          }
+        }
+      });
+  });
 }
 
 /**
@@ -292,161 +303,171 @@ export function checkDataIntegrityProofVerifyErrors({
     // to make an interop matrix with this suite
     this.matrix = true;
     this.report = true;
+    this.rowLabel = 'Test Name';
+    this.columnLabel = 'Verifier';
     if(isEcdsaTests) {
       this.implemented = [];
     } else {
       this.implemented = [...implemented.keys()];
     }
-    this.rowLabel = 'Test Name';
-    this.columnLabel = 'Verifier';
     for(const [vendorName, {endpoints}] of implemented) {
       if(!endpoints) {
         throw new Error(`Expected ${vendorName} to have endpoints.`);
       }
       for(const endpoint of endpoints) {
-        let testDescription;
         if(isEcdsaTests) {
           const {supportedEcdsaKeyTypes} = endpoint.settings;
           for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
             const keyType = checkKeyType(supportedEcdsaKeyType);
             this.implemented.push(`${vendorName}: ${keyType}`);
-            testDescription = `${vendorName}: ${keyType}`;
+            runDataIntegrityProofVerifyTests({
+              endpoints, expectedProofType,
+              testDescription: `${vendorName}: ${keyType}`, vendorName
+            });
           }
         } else {
-          testDescription = vendorName;
+          runDataIntegrityProofVerifyTests({
+            endpoints, expectedProofType, testDescription: vendorName,
+            vendorName
+          });
         }
-        const columnId = testDescription;
-        describe(testDescription, function() {
-          const [verifier] = endpoints;
-          if(!verifier) {
-            throw new Error(`Expected ${vendorName} to have a verifier.`);
-          }
-          let credentials;
-          before(async function() {
-            credentials = await generateTestData();
-          });
-          it('If the "proof" field is missing, an error MUST be raised.',
-            async function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              const credential = credentials.clone('issuedVc');
-              delete credential.proof;
-              await verificationFail({credential, verifier});
-            });
-          it('If the "proof" field is invalid, an error MUST be raised.',
-            async function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              const credential = credentials.clone('issuedVc');
-              credential.proof = null;
-              await verificationFail({credential, verifier});
-            });
-          it('If the "proof.type" field is missing, an error MUST be raised.',
-            async function() {
-              this.test.cell = {columnId, rowId: this.test.title};
-              const credential = credentials.clone('issuedVc');
-              delete credential.proof.type;
-              await verificationFail({credential, verifier});
-            });
-          it(`If the "proof.type" field is not the string ` +
-            `"${expectedProofType}", an error MUST be raised.`,
-          async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('invalidProofType');
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.verificationMethod" field is missing, an error ' +
-            'MUST be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('noVm');
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.verificationMethod" field is invalid, an error ' +
-            'MUST be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('invalidVm');
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.proofPurpose" field is missing, an error MUST ' +
-            'be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('noProofPurpose');
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.proofPurpose" field is invalid, an error MUST ' +
-            'be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('invalidProofPurpose');
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.proofPurpose" value does not match ' +
-            '"options.expectedProofPurpose", an error MUST be raised.',
-          async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('issuedVc');
-            await verificationFail({
-              credential, verifier, options: {
-                // this will fail since the vc generated is created with the
-                // assertionMethod proof purpose.
-                expectedProofPurpose: 'authentication'
-              }
-            });
-          });
-          it('If the "proof.proofValue" field is missing, an error MUST ' +
-            'be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            // proofValue is added after signing so we can
-            // safely delete it for this test
-            const credential = credentials.clone('issuedVc');
-            delete credential.proof.proofValue;
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.proofValue" field is invalid, an error MUST be ' +
-            'raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            // null should be an invalid proofValue for almost any proof
-            const credential = credentials.clone('issuedVc');
-            credential.proof.proofValue = null;
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.created" field is invalid, an error MUST be ' +
-            'raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            // FIXME: Fix test to check if a cryptographic suite requires the
-            // “proof.created” value
-            const credential = credentials.clone('invalidCreated');
-            await verificationFail({credential, verifier});
-          });
-          it('If the "proof.proofValue" field is not a multibase-encoded ' +
-            'base58-btc value, an error MUST be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('issuedVc');
-            // remove the initial z
-            credential.proof.proofValue = credential.proof.proofValue.slice(1);
-            await verificationFail({credential, verifier});
-          });
-          it('If the "options.domain" is set and it does not match ' +
-            '"proof.domain", an error MUST be raised.',
-          async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('invalidDomain');
-            await verificationFail({
-              credential, verifier, options: {
-                domain: 'domain.example'
-              }
-            });
-          });
-          it('If the "options.challenge" is set and it does not match ' +
-            '"proof.challenge", an error MUST be raised.', async function() {
-            this.test.cell = {columnId, rowId: this.test.title};
-            const credential = credentials.clone('invalidChallenge');
-            await verificationFail({
-              credential, verifier, options: {
-                domain: 'domain.example',
-                challenge: '1235abcd6789'
-              }
-            });
-          });
-        });
       }
     } // end for loop
   }); // end describe
+}
+
+function runDataIntegrityProofVerifyTests({
+  endpoints, expectedProofType, testDescription, vendorName
+}) {
+  const columnId = testDescription;
+  describe(testDescription, function() {
+    const [verifier] = endpoints;
+    if(!verifier) {
+      throw new Error(`Expected ${vendorName} to have a verifier.`);
+    }
+    let credentials;
+    before(async function() {
+      credentials = await generateTestData();
+    });
+    it('If the "proof" field is missing, an error MUST be raised.',
+      async function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        const credential = credentials.clone('issuedVc');
+        delete credential.proof;
+        await verificationFail({credential, verifier});
+      });
+    it('If the "proof" field is invalid, an error MUST be raised.',
+      async function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        const credential = credentials.clone('issuedVc');
+        credential.proof = null;
+        await verificationFail({credential, verifier});
+      });
+    it('If the "proof.type" field is missing, an error MUST be raised.',
+      async function() {
+        this.test.cell = {columnId, rowId: this.test.title};
+        const credential = credentials.clone('issuedVc');
+        delete credential.proof.type;
+        await verificationFail({credential, verifier});
+      });
+    it(`If the "proof.type" field is not the string ` +
+            `"${expectedProofType}", an error MUST be raised.`,
+    async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('invalidProofType');
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.verificationMethod" field is missing, an error ' +
+            'MUST be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('noVm');
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.verificationMethod" field is invalid, an error ' +
+            'MUST be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('invalidVm');
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.proofPurpose" field is missing, an error MUST ' +
+            'be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('noProofPurpose');
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.proofPurpose" field is invalid, an error MUST ' +
+            'be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('invalidProofPurpose');
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.proofPurpose" value does not match ' +
+            '"options.expectedProofPurpose", an error MUST be raised.',
+    async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('issuedVc');
+      await verificationFail({
+        credential, verifier, options: {
+          // this will fail since the vc generated is created with the
+          // assertionMethod proof purpose.
+          expectedProofPurpose: 'authentication'
+        }
+      });
+    });
+    it('If the "proof.proofValue" field is missing, an error MUST ' +
+            'be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      // proofValue is added after signing so we can
+      // safely delete it for this test
+      const credential = credentials.clone('issuedVc');
+      delete credential.proof.proofValue;
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.proofValue" field is invalid, an error MUST be ' +
+            'raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      // null should be an invalid proofValue for almost any proof
+      const credential = credentials.clone('issuedVc');
+      credential.proof.proofValue = null;
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.created" field is invalid, an error MUST be ' +
+            'raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      // FIXME: Fix test to check if a cryptographic suite requires the
+      // “proof.created” value
+      const credential = credentials.clone('invalidCreated');
+      await verificationFail({credential, verifier});
+    });
+    it('If the "proof.proofValue" field is not a multibase-encoded ' +
+            'base58-btc value, an error MUST be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('issuedVc');
+      // remove the initial z
+      credential.proof.proofValue = credential.proof.proofValue.slice(1);
+      await verificationFail({credential, verifier});
+    });
+    it('If the "options.domain" is set and it does not match ' +
+            '"proof.domain", an error MUST be raised.',
+    async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('invalidDomain');
+      await verificationFail({
+        credential, verifier, options: {
+          domain: 'domain.example'
+        }
+      });
+    });
+    it('If the "options.challenge" is set and it does not match ' +
+            '"proof.challenge", an error MUST be raised.', async function() {
+      this.test.cell = {columnId, rowId: this.test.title};
+      const credential = credentials.clone('invalidChallenge');
+      await verificationFail({
+        credential, verifier, options: {
+          domain: 'domain.example',
+          challenge: '1235abcd6789'
+        }
+      });
+    });
+  });
 }

--- a/index.js
+++ b/index.js
@@ -38,11 +38,7 @@ export function checkDataIntegrityProofFormat({
     this.report = true;
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Issuer';
-    if(isEcdsaTests) {
-      this.implemented = [];
-    } else {
-      this.implemented = [...implemented.keys()];
-    }
+    this.implemented = [];
     for(const [vendorName, {endpoints}] of implemented) {
       if(!endpoints) {
         throw new Error(`Expected ${vendorName} to have endpoints.`);
@@ -59,6 +55,7 @@ export function checkDataIntegrityProofFormat({
             });
           }
         } else {
+          this.implemented.push(vendorName);
           runDataIntegrityProofFormatTests({
             endpoints, expectedCryptoSuite, expectedProofTypes,
             testDescription: vendorName, vendorName
@@ -86,14 +83,14 @@ function runDataIntegrityProofFormatTests({
       proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
     });
     it('"proof" field MUST exist and MUST be either a single object or ' +
-        'an unordered set of objects.', function() {
+      'an unordered set of objects.', function() {
       this.test.cell = {columnId, rowId: this.test.title};
       should.exist(data, 'Expected data.');
       const proof = data.proof;
       should.exist(proof, 'Expected proof to exist.');
       const validType = isObjectOrArrayOfObjects(proof);
       validType.should.equal(true, 'Expected proof to be' +
-          'either an object or an unordered set of objects.');
+        'either an object or an unordered set of objects.');
     });
     it('if "proof.id" field exists, it MUST be a valid URL.', function() {
       this.test.cell = {columnId, rowId: this.test.title};
@@ -107,7 +104,7 @@ function runDataIntegrityProofFormatTests({
             err = e;
           }
           should.not.exist(err, 'Expected URL check of the "proof.id" ' +
-              'to not error.');
+            'to not error.');
           should.exist(result, 'Expected "proof.id" to be a URL.');
         }
       }
@@ -121,7 +118,7 @@ function runDataIntegrityProofFormatTests({
       }
     });
     it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
-        `and the associated document MUST include expected contexts.`,
+      `and the associated document MUST include expected contexts.`,
     function() {
       this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
@@ -145,9 +142,9 @@ function runDataIntegrityProofFormatTests({
 
         if(proof.type === 'Ed25519Signature2020') {
           const expectedContext =
-              'https://w3id.org/security/suites/ed25519-2020/v1';
+            'https://w3id.org/security/suites/ed25519-2020/v1';
           const hasExpectedContext =
-              data['@context'].includes(expectedContext);
+            data['@context'].includes(expectedContext);
           hasExpectedContext.should.equal(true);
         }
       }
@@ -159,12 +156,12 @@ function runDataIntegrityProofFormatTests({
           for(const proof of proofs) {
             proof.should.have.property('cryptosuite');
             proof.cryptosuite.should.be.a('string', 'Expected ' +
-                '"cryptosuite" property to be a string.');
+              '"cryptosuite" property to be a string.');
           }
         });
     }
     it('if "proof.created" field exists, it MUST be a valid ' +
-        'XMLSCHEMA-11 dateTimeStamp value.', function() {
+      'XMLSCHEMA-11 dateTimeStamp value.', function() {
       this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.created) {
@@ -175,7 +172,7 @@ function runDataIntegrityProofFormatTests({
       }
     });
     it('if "proof.expires" field exists, it MUST be a valid ' +
-        'XMLSCHEMA-11 dateTimeStamp value.', function() {
+      'XMLSCHEMA-11 dateTimeStamp value.', function() {
       this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.expires) {
@@ -198,9 +195,9 @@ function runDataIntegrityProofFormatTests({
             err = e;
           }
           should.not.exist(err, 'Expected URL check of the ' +
-              '"verificationMethod" to not error.');
+            '"verificationMethod" to not error.');
           should.exist(result, 'Expected "verificationMethod" ' +
-              'to be a URL');
+            'to be a URL');
         }
       });
     it('"proof.proofPurpose" field MUST exist and be a string.',
@@ -220,7 +217,7 @@ function runDataIntegrityProofFormatTests({
         }
       });
     it('The "proof.proofValue" field MUST be a multibase-encoded ' +
-        'base58-btc encoded value.', function() {
+      'base58-btc encoded value.', function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const multibase = 'z';
       proofs.some(proof => {
@@ -233,14 +230,14 @@ function runDataIntegrityProofFormatTests({
       );
     });
     it('if "proof.domain" field exists, it MUST be either a string, ' +
-        'or an unordered set of strings.', function() {
+      'or an unordered set of strings.', function() {
       this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.domain) {
           const validType = isStringOrArrayOfStrings(proof.domain);
           validType.should.equal(true, 'Expected ' +
-              '"proof.domain" to be either a string or an unordered ' +
-              'set of strings.');
+            '"proof.domain" to be either a string or an unordered ' +
+            'set of strings.');
         }
       }
     });
@@ -251,9 +248,9 @@ function runDataIntegrityProofFormatTests({
           if(proof.challenge) {
             // domain must be specified
             should.exist(proof.domain, 'Expected "proof.domain" ' +
-                'to be specified.');
+              'to be specified.');
             proof.challenge.should.be.a('string', 'Expected ' +
-                '"proof.challenge" to be a string.');
+              '"proof.challenge" to be a string.');
           }
         }
       });
@@ -263,7 +260,7 @@ function runDataIntegrityProofFormatTests({
         for(const proof of proofs) {
           if(proof.previousProof) {
             proof.previousProof.should.be.a('string', 'Expected ' +
-                '"proof.previousProof" to be a string.');
+              '"proof.previousProof" to be a string.');
           }
         }
       });
@@ -273,7 +270,7 @@ function runDataIntegrityProofFormatTests({
         for(const proof of proofs) {
           if(proof.nonce) {
             proof.nonce.should.be.a('string', 'Expected "proof.nonce" ' +
-                'to be a string.');
+              'to be a string.');
           }
         }
       });
@@ -305,11 +302,7 @@ export function checkDataIntegrityProofVerifyErrors({
     this.report = true;
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Verifier';
-    if(isEcdsaTests) {
-      this.implemented = [];
-    } else {
-      this.implemented = [...implemented.keys()];
-    }
+    this.implemented = [];
     for(const [vendorName, {endpoints}] of implemented) {
       if(!endpoints) {
         throw new Error(`Expected ${vendorName} to have endpoints.`);
@@ -326,6 +319,7 @@ export function checkDataIntegrityProofVerifyErrors({
             });
           }
         } else {
+          this.implemented.push(vendorName);
           runDataIntegrityProofVerifyTests({
             endpoints, expectedProofType, testDescription: vendorName,
             vendorName
@@ -371,38 +365,38 @@ function runDataIntegrityProofVerifyTests({
         await verificationFail({credential, verifier});
       });
     it(`If the "proof.type" field is not the string ` +
-            `"${expectedProofType}", an error MUST be raised.`,
+      `"${expectedProofType}", an error MUST be raised.`,
     async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('invalidProofType');
       await verificationFail({credential, verifier});
     });
     it('If the "proof.verificationMethod" field is missing, an error ' +
-            'MUST be raised.', async function() {
+      'MUST be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('noVm');
       await verificationFail({credential, verifier});
     });
     it('If the "proof.verificationMethod" field is invalid, an error ' +
-            'MUST be raised.', async function() {
+      'MUST be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('invalidVm');
       await verificationFail({credential, verifier});
     });
     it('If the "proof.proofPurpose" field is missing, an error MUST ' +
-            'be raised.', async function() {
+      'be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('noProofPurpose');
       await verificationFail({credential, verifier});
     });
     it('If the "proof.proofPurpose" field is invalid, an error MUST ' +
-            'be raised.', async function() {
+      'be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('invalidProofPurpose');
       await verificationFail({credential, verifier});
     });
     it('If the "proof.proofPurpose" value does not match ' +
-            '"options.expectedProofPurpose", an error MUST be raised.',
+      '"options.expectedProofPurpose", an error MUST be raised.',
     async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('issuedVc');
@@ -415,7 +409,7 @@ function runDataIntegrityProofVerifyTests({
       });
     });
     it('If the "proof.proofValue" field is missing, an error MUST ' +
-            'be raised.', async function() {
+      'be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       // proofValue is added after signing so we can
       // safely delete it for this test
@@ -424,7 +418,7 @@ function runDataIntegrityProofVerifyTests({
       await verificationFail({credential, verifier});
     });
     it('If the "proof.proofValue" field is invalid, an error MUST be ' +
-            'raised.', async function() {
+      'raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       // null should be an invalid proofValue for almost any proof
       const credential = credentials.clone('issuedVc');
@@ -432,7 +426,7 @@ function runDataIntegrityProofVerifyTests({
       await verificationFail({credential, verifier});
     });
     it('If the "proof.created" field is invalid, an error MUST be ' +
-            'raised.', async function() {
+      'raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       // FIXME: Fix test to check if a cryptographic suite requires the
       // “proof.created” value
@@ -440,7 +434,7 @@ function runDataIntegrityProofVerifyTests({
       await verificationFail({credential, verifier});
     });
     it('If the "proof.proofValue" field is not a multibase-encoded ' +
-            'base58-btc value, an error MUST be raised.', async function() {
+      'base58-btc value, an error MUST be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('issuedVc');
       // remove the initial z
@@ -448,7 +442,7 @@ function runDataIntegrityProofVerifyTests({
       await verificationFail({credential, verifier});
     });
     it('If the "options.domain" is set and it does not match ' +
-            '"proof.domain", an error MUST be raised.',
+      '"proof.domain", an error MUST be raised.',
     async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('invalidDomain');
@@ -459,7 +453,7 @@ function runDataIntegrityProofVerifyTests({
       });
     });
     it('If the "options.challenge" is set and it does not match ' +
-            '"proof.challenge", an error MUST be raised.', async function() {
+      '"proof.challenge", an error MUST be raised.', async function() {
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('invalidChallenge');
       await verificationFail({

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
  */
 import {
-  createInitialVc, dateRegex, getKeyType, isObjectOrArrayOfObjects,
+  checkKeyType, createInitialVc, dateRegex, isObjectOrArrayOfObjects,
   isStringOrArrayOfStrings, shouldBeBs58, verificationFail
 } from './helpers.js';
 import chai from 'chai';
@@ -38,13 +38,6 @@ export function checkDataIntegrityProofFormat({
     this.report = true;
     if(isEcdsaTests) {
       this.implemented = [];
-      for(const [name, {endpoints}] of implemented) {
-        for(const endpoint of endpoints) {
-          const {supportedEcdsaKeyTypes} = endpoint.settings;
-          const keyType = getKeyType(supportedEcdsaKeyTypes);
-          this.implemented.push(`${name}: ${keyType}`);
-        }
-      }
     } else {
       this.implemented = [...implemented.keys()];
     }
@@ -58,8 +51,11 @@ export function checkDataIntegrityProofFormat({
         let testDescription;
         if(isEcdsaTests) {
           const {supportedEcdsaKeyTypes} = endpoint.settings;
-          const keyType = getKeyType(supportedEcdsaKeyTypes);
-          testDescription = `${vendorName}: ${keyType}`;
+          for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
+            const keyType = checkKeyType(supportedEcdsaKeyType);
+            this.implemented.push(`${vendorName}: ${keyType}`);
+            testDescription = `${vendorName}: ${keyType}`;
+          }
         } else {
           testDescription = vendorName;
         }
@@ -298,13 +294,6 @@ export function checkDataIntegrityProofVerifyErrors({
     this.report = true;
     if(isEcdsaTests) {
       this.implemented = [];
-      for(const [name, {endpoints}] of implemented) {
-        for(const endpoint of endpoints) {
-          const {supportedEcdsaKeyTypes} = endpoint.settings;
-          const keyType = getKeyType(supportedEcdsaKeyTypes);
-          this.implemented.push(`${name}: ${keyType}`);
-        }
-      }
     } else {
       this.implemented = [...implemented.keys()];
     }
@@ -318,8 +307,11 @@ export function checkDataIntegrityProofVerifyErrors({
         let testDescription;
         if(isEcdsaTests) {
           const {supportedEcdsaKeyTypes} = endpoint.settings;
-          const keyType = getKeyType(supportedEcdsaKeyTypes);
-          testDescription = `${vendorName}: ${keyType}`;
+          for(const supportedEcdsaKeyType of supportedEcdsaKeyTypes) {
+            const keyType = checkKeyType(supportedEcdsaKeyType);
+            this.implemented.push(`${vendorName}: ${keyType}`);
+            testDescription = `${vendorName}: ${keyType}`;
+          }
         } else {
           testDescription = vendorName;
         }


### PR DESCRIPTION
- The flag `isEcdsaTests ` needs to be added since unlike the other test suites, the ecdsa test suite requires key type to be specified along with the implementation names in the report. Usage can be seen here https://github.com/w3c/vc-di-ecdsa-test-suite/pull/19