### PR TITLE
Fix verifier test on invalid proof.proofValue value.

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -69,6 +69,33 @@ export const verificationFail = async ({
   );
 };
 
+export function expectedMultibasePrefix(cryptosuite) {
+  const b64urlNoPadSuites = ['ecdsa-sd-2023', 'bbs-2023'];
+
+  if(b64urlNoPadSuites.includes(cryptosuite)) {
+    return {
+      prefix: 'u',
+      name: 'base64url-no-pad'
+    };
+  }
+
+  return {
+    prefix: 'z',
+    name: 'base58btc'
+  };
+}
+
+export function isValidMultibaseEncoded(rawValue, multibasePrefix) {
+  switch(multibasePrefix) {
+    case 'z':
+      return shouldBeBs58(rawValue);
+    case 'u':
+      return shouldBeBase64NoPadUrl(rawValue);
+    default:
+      throw new Error(`Unhandled encoding prefix: ${multibasePrefix}.`);
+  }
+}
+
 // Regex for valid  XML Schema 1.1 dateTimeStamp value
 export const dateRegex = new RegExp('-?([1-9][0-9]{3,}|0[0-9]{3})' +
   '-(0[1-9]|1[0-2])' +

--- a/index.js
+++ b/index.js
@@ -454,7 +454,7 @@ function runDataIntegrityProofVerifyTests({
       this.test.cell = {columnId, rowId: this.test.title};
       const credential = credentials.clone('issuedVc');
 
-      // Remove the multibase header
+      // Remove the multibase header to cause validation error
       credential.proof.proofValue = credential.proof.proofValue.slice(1);
 
       await verificationFail({credential, verifier});


### PR DESCRIPTION
We already assert that a proof.proofValue is of a specific format according to the spec (e.g., base58btc or base64url-no-ad). The only requirement on the verifier side is that the value is multibase encoded.

This updates the test title to match the language of the spec and avoids specifying any specific format.