### PR TITLE
Add shared gens section & invalid cryptosuite generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # data-integrity-test-suite-assertion Changelog
 
+## 1.2.0 -
+
+### Added
+- A new section shared in generators with shared generators.
+
 ## 1.1.0 - 2024-06-13
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ export function checkDataIntegrityProofVerifyErrors({
   }); // end describe
 }
 
-export {generators} from './vc-generator/generators.js';
+export {generators, issueCloned} from './vc-generator/generators.js';
 export {
   createInitialVc, dateRegex, expectedMultibasePrefix,
   isObjectOrArrayOfObjects,

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -12,27 +12,32 @@ const {CredentialIssuancePurpose} = vc;
 
 // generator categories
 export const generators = {
+  // creates test vectors for `proof.created`
   created: {
     noCreated,
     invalidCreated,
     vcCreatedOneYearAgo
   },
+  // creates test vectors for Authentication Purpose tests
   authentication: {
     invalidDomain,
     invalidChallenge
   },
+  // these generators are needed for DI specific tests
+  // and maybe be needed in suite specific tests
   mandatory: {
-    issuedVc,
-    invalidProofType,
     noVerificationMethod,
-    invalidVm,
     noProofPurpose,
-    invalidProofPurpose
+    issuedVc,
+    invalidCryptosuite,
+    invalidProofPurpose,
+    invalidProofType,
+    invalidVm,
   },
   // creates a set of shared test vector generators
-  shared: {
-    invalidCryptosuite
-  }
+  // not necessarily used in DI Assertion itself, but used
+  // in multiple suites
+  shared: {}
 };
 
 /**

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -120,12 +120,18 @@ function noCreated({suite, selectiveSuite, credential}) {
 }
 
 // both base and derived will have an invalid proof.type
-function invalidProofType({suite, selectiveSuite, credential}) {
-  suite.type = 'UnknownProofType';
+function invalidProofType({
+  suite,
+  selectiveSuite,
+  credential,
+  proofType = 'UnknownProofType'
+}) {
+  suite.type = proofType;
   if(selectiveSuite) {
     const proofId = 'urn:uuid:no-proof-type-test';
     suite.proof = {id: proofId};
     selectiveSuite._cryptosuite.options.proofId = proofId;
+    selectiveSuite.type = proofType;
   }
   return {suite, selectiveSuite, credential};
 }

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -28,6 +28,10 @@ export const generators = {
     invalidVm,
     noProofPurpose,
     invalidProofPurpose
+  },
+  // creates a set of shared test vector generators
+  shared: {
+    invalidCryptosuite
   }
 };
 
@@ -122,6 +126,21 @@ function invalidProofType({suite, selectiveSuite, credential}) {
     const proofId = 'urn:uuid:no-proof-type-test';
     suite.proof = {id: proofId};
     selectiveSuite._cryptosuite.options.proofId = proofId;
+  }
+  return {suite, selectiveSuite, credential};
+}
+
+// chances the cryptosuite name to something else for
+// invalid cryptosuite tests
+function invalidCryptosuite({
+  suite,
+  selectiveSuite,
+  credential,
+  cryptosuiteName = 'UnknownCryptosuite'
+}) {
+  suite.cryptosuite = cryptosuiteName;
+  if(selectiveSuite) {
+    selectiveSuite.cryptosuite = cryptosuiteName;
   }
   return {suite, selectiveSuite, credential};
 }


### PR DESCRIPTION
Features:
1. exports `issueCloned`
2. Adds a new `shared` generators section for invalid cryptosuite name tests.