### PR TITLE
Add invalid cryptosuite test

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,7 @@ export const validVc = require('./validVc.json');
  * @param {Array<string>} [options.expectedProofTypes] - An option to specify
  *   the expected proof types. The default value is set to
  *   ['DataIntegrityProof'].
- * @param {boolean} [options.expectedCryptoSuite] - A boolean option to specify
- *   if "cryptosuite" field is expected in the proof or not. The default value
- *   is set to true.
- * @param {boolean} [options.isEcdsaTests] - A boolean option to specify
+  * @param {boolean} [options.isEcdsaTests] - A boolean option to specify
  *   if it is used in ecdsa test suite or not. The default value
  *   is set to false.
  * @param {string} [options.testDescription] - An option to define
@@ -36,8 +33,7 @@ export const validVc = require('./validVc.json');
  */
 export function checkDataIntegrityProofFormat({
   implemented, expectedProofTypes = ['DataIntegrityProof'],
-  expectedCryptoSuite = true, isEcdsaTests = false,
-  testDescription = 'Data Integrity (issuer)'
+  isEcdsaTests = false, testDescription = 'Data Integrity (issuer)'
 } = {}) {
   return describe(testDescription, function() {
     // this will tell the report
@@ -58,14 +54,14 @@ export function checkDataIntegrityProofFormat({
             const keyType = checkKeyType(supportedEcdsaKeyType);
             this.implemented.push(`${vendorName}: ${keyType}`);
             runDataIntegrityProofFormatTests({
-              endpoints, expectedCryptoSuite, expectedProofTypes,
+              endpoints, expectedProofTypes,
               testDescription: `${vendorName}: ${keyType}`, vendorName
             });
           }
         } else {
           this.implemented.push(vendorName);
           runDataIntegrityProofFormatTests({
-            endpoints, expectedCryptoSuite, expectedProofTypes,
+            endpoints, expectedProofTypes,
             testDescription: vendorName, vendorName
           });
         }

--- a/suites/create.js
+++ b/suites/create.js
@@ -17,6 +17,12 @@ export function runDataIntegrityProofFormatTests({
 }) {
   return describe(testDescription, function() {
     const columnId = testDescription;
+    beforeEach(function() {
+      this.currentTest.cell = {
+        columnId,
+        rowId: this.currentTest.title
+      };
+    });
     let proofs = [];
     let data;
     before(async function() {
@@ -29,7 +35,6 @@ export function runDataIntegrityProofFormatTests({
     });
     it('"proof" field MUST exist and MUST be either a single object or ' +
       'an unordered set of objects.', function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       should.exist(data, 'Expected data.');
       const proof = data.proof;
       should.exist(proof, 'Expected proof to exist.');
@@ -38,7 +43,6 @@ export function runDataIntegrityProofFormatTests({
         'either an object or an unordered set of objects.');
     });
     it('if "proof.id" field exists, it MUST be a valid URL.', function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.id) {
           let result;
@@ -55,7 +59,6 @@ export function runDataIntegrityProofFormatTests({
       }
     });
     it('"proof.type" field MUST exist and be a string.', function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         proof.should.have.property('type');
         proof.type.should.be.a(
@@ -65,7 +68,6 @@ export function runDataIntegrityProofFormatTests({
     it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
       `and the associated document MUST include expected contexts.`,
     function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         proof.should.have.property('type');
         proof.type.should.be.a(
@@ -97,7 +99,6 @@ export function runDataIntegrityProofFormatTests({
     if(expectedCryptoSuite) {
       it('"proof.cryptosuite" field MUST exist and be a string.',
         function() {
-          this.test.cell = {columnId, rowId: this.test.title};
           for(const proof of proofs) {
             proof.should.have.property('cryptosuite');
             proof.cryptosuite.should.be.a('string', 'Expected ' +
@@ -123,7 +124,6 @@ export function runDataIntegrityProofFormatTests({
     });
     it('if "proof.created" field exists, it MUST be a valid ' +
       'XMLSCHEMA-11 dateTimeStamp value.', function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.created) {
           // check if "created" is a valid XML Schema 1.1 dateTimeStamp
@@ -134,7 +134,6 @@ export function runDataIntegrityProofFormatTests({
     });
     it('if "proof.expires" field exists, it MUST be a valid ' +
       'XMLSCHEMA-11 dateTimeStamp value.', function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.expires) {
           // check if "created" is a valid XML Schema 1.1 dateTimeStamp
@@ -145,7 +144,6 @@ export function runDataIntegrityProofFormatTests({
     });
     it('"proof.verificationMethod" field MUST exist and be a valid URL.',
       function() {
-        this.test.cell = {columnId, rowId: this.test.title};
         for(const proof of proofs) {
           proof.should.have.property('verificationMethod');
           let result;
@@ -163,7 +161,6 @@ export function runDataIntegrityProofFormatTests({
       });
     it('"proof.proofPurpose" field MUST exist and be a string.',
       function() {
-        this.test.cell = {columnId, rowId: this.test.title};
         for(const proof of proofs) {
           proof.should.have.property('proofPurpose');
           proof.proofPurpose.should.be.a('string');
@@ -171,7 +168,6 @@ export function runDataIntegrityProofFormatTests({
       });
     it('"proof.proofValue" field MUST exist and be a string.',
       function() {
-        this.test.cell = {columnId, rowId: this.test.title};
         for(const proof of proofs) {
           proof.should.have.property('proofValue');
           proof.proofValue.should.be.a('string');
@@ -180,8 +176,6 @@ export function runDataIntegrityProofFormatTests({
     it('The contents of the value ("proof.proofValue") MUST be expressed ' +
     'with a header and encoding as described in Section 2.4 Multibase.',
     function() {
-      this.test.cell = {columnId, rowId: this.test.title};
-
       for(const proof of proofs) {
         const {
           prefix: expectedPrefix,
@@ -203,7 +197,6 @@ export function runDataIntegrityProofFormatTests({
     });
     it('if "proof.domain" field exists, it MUST be either a string, ' +
       'or an unordered set of strings.', function() {
-      this.test.cell = {columnId, rowId: this.test.title};
       for(const proof of proofs) {
         if(proof.domain) {
           const validType = isStringOrArrayOfStrings(proof.domain);
@@ -215,7 +208,6 @@ export function runDataIntegrityProofFormatTests({
     });
     it('if "proof.challenge" field exists, it MUST be a string.',
       function() {
-        this.test.cell = {columnId, rowId: this.test.title};
         for(const proof of proofs) {
           if(proof.challenge) {
             // domain must be specified
@@ -228,7 +220,6 @@ export function runDataIntegrityProofFormatTests({
       });
     it('if "proof.previousProof" field exists, it MUST be a string.',
       function() {
-        this.test.cell = {columnId, rowId: this.test.title};
         for(const proof of proofs) {
           if(proof.previousProof) {
             proof.previousProof.should.be.a('string', 'Expected ' +
@@ -238,7 +229,6 @@ export function runDataIntegrityProofFormatTests({
       });
     it('if "proof.nonce" field exists, it MUST be a string.',
       function() {
-        this.test.cell = {columnId, rowId: this.test.title};
         for(const proof of proofs) {
           if(proof.nonce) {
             proof.nonce.should.be.a('string', 'Expected "proof.nonce" ' +

--- a/suites/create.js
+++ b/suites/create.js
@@ -12,7 +12,7 @@ import {validVc} from '../index.js';
 const should = chai.should();
 
 export function runDataIntegrityProofFormatTests({
-  endpoints, expectedCryptoSuite, expectedProofTypes, testDescription,
+  endpoints, expectedProofTypes, testDescription,
   vendorName
 }) {
   return describe(testDescription, function() {
@@ -62,7 +62,7 @@ export function runDataIntegrityProofFormatTests({
       for(const proof of proofs) {
         proof.should.have.property('type');
         proof.type.should.be.a(
-          'string', 'Expected "proof.type" to be a string.');
+          'Array', 'Expected "proof.type" to be a string.');
       }
     });
     it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +
@@ -96,16 +96,6 @@ export function runDataIntegrityProofFormatTests({
         }
       }
     });
-    if(expectedCryptoSuite) {
-      it('"proof.cryptosuite" field MUST exist and be a string.',
-        function() {
-          for(const proof of proofs) {
-            proof.should.have.property('cryptosuite');
-            proof.cryptosuite.should.be.a('string', 'Expected ' +
-              '"cryptosuite" property to be a string.');
-          }
-        });
-    }
     it('If the proof type is DataIntegrityProof, cryptosuite MUST be ' +
     'specified; otherwise, cryptosuite MAY be specified. If specified, its ' +
     'value MUST be a string.', function() {

--- a/suites/create.js
+++ b/suites/create.js
@@ -105,6 +105,22 @@ export function runDataIntegrityProofFormatTests({
           }
         });
     }
+    it('If the proof type is DataIntegrityProof, cryptosuite MUST be ' +
+    'specified; otherwise, cryptosuite MAY be specified. If specified, its ' +
+    'value MUST be a string.', function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#introduction:~:text=If%20the%20proof%20type%20is%20DataIntegrityProof%2C%20cryptosuite%20MUST%20be%20specified%3B%20otherwise%2C%20cryptosuite%20MAY%20be%20specified.%20If%20specified%2C%20its%20value%20MUST%20be%20a%20string.';
+      for(const proof of proofs) {
+        if(proof.type && proof.type === 'DataIntegrityProof') {
+          should.exist(
+            proof.cryptosuite,
+            'If the proof type is DataIntegrityProof, cryptosuite MUST ' +
+            'be specified');
+          proof.cryptosuite.should.be.a(
+            'string',
+            'cryptosuite value MUST be a string.');
+        }
+      }
+    });
     it('if "proof.created" field exists, it MUST be a valid ' +
       'XMLSCHEMA-11 dateTimeStamp value.', function() {
       this.test.cell = {columnId, rowId: this.test.title};

--- a/suites/create.js
+++ b/suites/create.js
@@ -62,7 +62,7 @@ export function runDataIntegrityProofFormatTests({
       for(const proof of proofs) {
         proof.should.have.property('type');
         proof.type.should.be.a(
-          'Array', 'Expected "proof.type" to be a string.');
+          'string', 'Expected "proof.type" to be a string.');
       }
     });
     it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +


### PR DESCRIPTION
1. Adds one new test from DI Spec
2. DRYs up the `this.cell` logic into a single `beforeEach` statement thanks to @JSAssassin 
3. Deprecates the `expectedCryptosuite` property which is weirdly a `boolean` when that sounds more like a string.