### PR TITLE
Add issuer cryptosuite type test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # data-integrity-test-suite-assertion Changelog
 
-## 1.2.0 -
+## 1.2.0 - 2024-06-18
 
 ### Added
 - A new section shared in generators with shared generators.
 - Generators pass unused parameters to next generator.
 - Export both `issueCloned` and `deriveCloned`.
+- A new parameter `cryptosuiteName` for the issuer tests.
 
 ## 1.1.0 - 2024-06-13
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ export const validVc = require('./validVc.json');
  * Validates the structure of the "proof" property on a digital document.
  *
  * @param {object} options - Options to use.
+ * @param {string} options.cryptosuiteName - A cryptosuite name.
  * @param {Map<string,object>} options.implemented - The vendors being tested.
  * @param {Array<string>} [options.expectedProofTypes] - An option to specify
  *   the expected proof types. The default value is set to
@@ -33,7 +34,8 @@ export const validVc = require('./validVc.json');
  */
 export function checkDataIntegrityProofFormat({
   implemented, expectedProofTypes = ['DataIntegrityProof'],
-  isEcdsaTests = false, testDescription = 'Data Integrity (issuer)'
+  cryptosuiteName, isEcdsaTests = false,
+  testDescription = 'Data Integrity (issuer)'
 } = {}) {
   return describe(testDescription, function() {
     // this will tell the report
@@ -61,7 +63,7 @@ export function checkDataIntegrityProofFormat({
         } else {
           this.implemented.push(vendorName);
           runDataIntegrityProofFormatTests({
-            endpoints, expectedProofTypes,
+            cryptosuiteName, endpoints, expectedProofTypes,
             testDescription: vendorName, vendorName
           });
         }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@digitalbazaar/vc": "github:digitalbazaar/vc#update-vc-2.0",
     "@digitalcredentials/did-context": "^1.0.0",
     "credentials-context": "^2.0.0",
+    "jsonld": "^8.3.2",
     "jsonld-document-loader": "^2.0.0",
     "jsonld-signatures": "^11.2.1",
     "klona": "^2.0.5",

--- a/suites/create.js
+++ b/suites/create.js
@@ -251,10 +251,12 @@ export function runDataIntegrityProofFormatTests({
         should.exist(
           cryptosuite,
           `Expected graph to have property ${cryptoProp}`);
-        const cryptoString = cryptosuite.some(c => c?.['@type'] === cryptoType);
+        const cryptoString = cryptosuite.some(c =>
+          c?.['@type'] === cryptoType && c?.['@value'] === cryptosuiteName);
         cryptoString.should.equal(
           true,
-          `Expected at least one cryptosuite with type ${cryptoType}`);
+          `Expected at least one cryptosuite with @type ${cryptoType} and ` +
+          `@value ${cryptosuiteName}`);
       });
     }
   });

--- a/suites/create.js
+++ b/suites/create.js
@@ -230,6 +230,7 @@ export function runDataIntegrityProofFormatTests({
     if(cryptosuiteName) {
       it('The value of the cryptosuite property MUST be a string that ' +
         'identifies the cryptographic suite.', async function() {
+        this.test.link = 'https://w3c.github.io/vc-data-integrity/#introduction:~:text=The%20value%20of%20the%20cryptosuite%20property%20MUST%20be%20a%20string%20that%20identifies%20the%20cryptographic%20suite.%20If%20the%20processing%20environment%20supports%20subtypes%20of%20string%2C%20the%20type%20of%20the%20cryptosuite%20value%20MUST%20be%20the%20https%3A//w3id.org/security%23cryptosuiteString%20subtype%20of%20string.';
         const hasCryptosuiteName = proofs.some(
           p => p?.cryptosuite === cryptosuiteName);
         hasCryptosuiteName.should.equal(

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -16,7 +16,8 @@ describe('Test checkDataIntegrityProofFormat()', function() {
   it('should pass if implemented returns a valid Vc.', function() {
     checkDataIntegrityProofFormat({
       implemented: validIssuerImplementations,
-      tag: 'Test-Issuer-Valid'
+      tag: 'Test-Issuer-Valid',
+      cryptosuiteName: 'eddsa-2022'
     });
   });
   // this results in the test suite reporting failure when it is


### PR DESCRIPTION
Adds issuer tests for cryptosuiteName and the jsonld type of cryptosuite.

This is a draft as other suites will need to turn on cryptosuite specific support via cryptosuiteName.