### PR TITLE
Pass cryptosuiteName in case where isEcdsa = true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ export function checkDataIntegrityProofFormat({
             const keyType = checkKeyType(supportedEcdsaKeyType);
             this.implemented.push(`${vendorName}: ${keyType}`);
             runDataIntegrityProofFormatTests({
-              endpoints, expectedProofTypes,
+              cryptosuiteName, endpoints, expectedProofTypes,
               testDescription: `${vendorName}: ${keyType}`, vendorName
             });
           }


### PR DESCRIPTION
Patch release: passes cryptosuiteName even if `isEcdsa = true`.