### PR TITLE
Should expand to url

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2024 Digital Bazaar, Inc.
  */
 import chai from 'chai';
+import jsonld from 'jsonld';
 
 const should = chai.should();
 // RegExp with bs58 characters in it
@@ -134,4 +135,17 @@ export function shouldHaveProof({vc}) {
   vc.should.be.an('object', 'Expected Verifiable Credential to be an object.');
   const {proof} = vc;
   should.exist(proof, 'Expected proof to exist.');
+}
+
+export async function shouldMapToUrl({doc, term, prop}) {
+  const expanded = await jsonld.expand({...doc});
+  for(const terms of expanded) {
+    const termProps = terms[term];
+    should.exist(termProps,
+      `Expected property "${term}" to exist.`);
+    for(const term of termProps) {
+      const url = term [prop];
+      shouldBeUrl({url, prop: `"${term}" "${prop}"`});
+    }
+  }
 }

--- a/suites/create.js
+++ b/suites/create.js
@@ -246,6 +246,12 @@ export function runDataIntegrityProofFormatTests({
         const cryptoProp = 'https://w3id.org/security#cryptosuite';
         const cryptoType = 'https://w3id.org/security#cryptosuiteString';
         for(const {cryptosuite, type} of proofs) {
+          should.exist(cryptosuite,
+            'Expected property "proof.cryptosuite" to exist.');
+          should.exist(type,
+            'Expected property "proof.type" to exist.');
+          should.exist(data['@context'],
+            'Expected VC to have property "@context".');
           const expanded = await jsonld.expand({
             '@context': data['@context'],
             cryptosuite,
@@ -259,7 +265,7 @@ export function runDataIntegrityProofFormatTests({
               suite['@type'] === cryptoType &&
               suite['@value'] == cryptosuiteName);
             hasTypeName.should.equal(true,
-              `Expected cryptosuite with ame ${cryptosuiteName} and ` +
+              `Expected cryptosuite with name ${cryptosuiteName} & ` +
               `subtype ${cryptoType}`);
           }
         }

--- a/suites/create.js
+++ b/suites/create.js
@@ -243,21 +243,20 @@ export function runDataIntegrityProofFormatTests({
         'be the https://w3id.org/security#cryptosuiteString subtype of string.',
       async function() {
         this.test.link = 'https://w3c.github.io/vc-data-integrity/#introduction:~:text=The%20value%20of%20the%20cryptosuite%20property%20MUST%20be%20a%20string%20that%20identifies%20the%20cryptographic%20suite.%20If%20the%20processing%20environment%20supports%20subtypes%20of%20string%2C%20the%20type%20of%20the%20cryptosuite%20value%20MUST%20be%20the%20https%3A//w3id.org/security%23cryptosuiteString%20subtype%20of%20string.';
-        const [flattened] = await jsonld.flatten(data);
-        const [graph] = flattened['@graph'];
-        should.exist(graph, 'Expected flattened VC to have a graph.');
         const cryptoProp = 'https://w3id.org/security#cryptosuite';
-        const cryptosuite = graph[cryptoProp];
         const cryptoType = 'https://w3id.org/security#cryptosuiteString';
-        should.exist(
-          cryptosuite,
-          `Expected graph to have property ${cryptoProp}`);
-        const cryptoString = cryptosuite.some(c =>
-          c?.['@type'] === cryptoType && c?.['@value'] === cryptosuiteName);
-        cryptoString.should.equal(
-          true,
-          `Expected at least one cryptosuite with @type ${cryptoType} and ` +
-          `@value ${cryptosuiteName}`);
+        for(const {cryptosuite, type} of proofs) {
+          const [expanded] = await jsonld.expand({
+            '@context': data['@context'],
+            cryptosuite,
+            type
+          });
+          const [cryptoProperties] = expanded[cryptoProp];
+          should.exist(cryptoProperties,
+            `Expected property ${cryptoProp} to exist.`);
+          cryptoProperties.should.have.property('@type', cryptoType);
+          cryptoProperties.should.have.property('@value', cryptosuiteName);
+        }
       });
     }
   });

--- a/suites/create.js
+++ b/suites/create.js
@@ -265,8 +265,8 @@ export function runDataIntegrityProofFormatTests({
               suite['@type'] === cryptoType &&
               suite['@value'] == cryptosuiteName);
             hasTypeName.should.equal(true,
-              `Expected cryptosuite with name ${cryptosuiteName} & ` +
-              `subtype ${cryptoType}`);
+              `Expected ${cryptoProp} with @value ${cryptosuiteName} & ` +
+              `@type ${cryptoType}`);
           }
         }
       });

--- a/suites/create.js
+++ b/suites/create.js
@@ -246,16 +246,22 @@ export function runDataIntegrityProofFormatTests({
         const cryptoProp = 'https://w3id.org/security#cryptosuite';
         const cryptoType = 'https://w3id.org/security#cryptosuiteString';
         for(const {cryptosuite, type} of proofs) {
-          const [expanded] = await jsonld.expand({
+          const expanded = await jsonld.expand({
             '@context': data['@context'],
             cryptosuite,
             type
           });
-          const [cryptoProperties] = expanded[cryptoProp];
-          should.exist(cryptoProperties,
-            `Expected property ${cryptoProp} to exist.`);
-          cryptoProperties.should.have.property('@type', cryptoType);
-          cryptoProperties.should.have.property('@value', cryptosuiteName);
+          for(const terms of expanded) {
+            const cryptoProperties = terms[cryptoProp];
+            should.exist(cryptoProperties,
+              `Expected property ${cryptoProp} to exist.`);
+            const hasTypeName = cryptoProperties.some(suite =>
+              suite['@type'] === cryptoType &&
+              suite['@value'] == cryptosuiteName);
+            hasTypeName.should.equal(true,
+              `Expected cryptosuite with ame ${cryptosuiteName} and ` +
+              `subtype ${cryptoType}`);
+          }
         }
       });
     }

--- a/suites/create.js
+++ b/suites/create.js
@@ -145,23 +145,21 @@ export function runDataIntegrityProofFormatTests({
         }
       }
     });
-    it('"proof.verificationMethod" field MUST exist and be a valid URL.',
-      function() {
-        for(const proof of proofs) {
-          proof.should.have.property('verificationMethod');
-          let result;
-          let err;
-          try {
-            result = new URL(proof.verificationMethod);
-          } catch(e) {
-            err = e;
-          }
-          should.not.exist(err, 'Expected URL check of the ' +
-            '"verificationMethod" to not error.');
-          should.exist(result, 'Expected "verificationMethod" ' +
-            'to be a URL');
-        }
-      });
+    it('A verification method is the means and information needed to verify ' +
+        'the proof. If included, the value MUST be a string that maps ' +
+        'to a [URL]', async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=A%20verification%20method%20is%20the%20means%20and%20information%20needed%20to%20verify%20the%20proof.%20If%20included%2C%20the%20value%20MUST%20be%20a%20string%20that%20maps%20to%20a%20%5BURL%5D.';
+      for(const proof of proofs) {
+        shouldMapToUrl({
+          doc: {
+            '@context': data['@context'],
+            ...proof
+          },
+          term: 'https://w3id.org/security#verificationMethod',
+          prop: '@value'
+        });
+      }
+    });
     it('The reason the proof was created ("proof.proofPurpose") MUST be ' +
         'specified as a string that maps to a URL', async function() {
       this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=The%20reason%20the%20proof%20was%20created%20MUST%20be%20specified%20as%20a%20string%20that%20maps%20to%20a%20URL';

--- a/suites/create.js
+++ b/suites/create.js
@@ -150,13 +150,13 @@ export function runDataIntegrityProofFormatTests({
         'to a [URL]', async function() {
       this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=A%20verification%20method%20is%20the%20means%20and%20information%20needed%20to%20verify%20the%20proof.%20If%20included%2C%20the%20value%20MUST%20be%20a%20string%20that%20maps%20to%20a%20%5BURL%5D.';
       for(const proof of proofs) {
-        shouldMapToUrl({
+        await shouldMapToUrl({
           doc: {
             '@context': data['@context'],
             ...proof
           },
           term: 'https://w3id.org/security#verificationMethod',
-          prop: '@value'
+          prop: '@id'
         });
       }
     });

--- a/suites/create.js
+++ b/suites/create.js
@@ -74,7 +74,7 @@ export function runDataIntegrityProofFormatTests({
         for(const term of expanded) {
           const types = term[prop];
           should.exist(types, 'Expected @type to exist.');
-          term[prop].every(url => shouldBeUrl({url, prop}));
+          types.every(url => shouldBeUrl({url, prop}));
         }
       }
     });
@@ -162,13 +162,22 @@ export function runDataIntegrityProofFormatTests({
             'to be a URL');
         }
       });
-    it('"proof.proofPurpose" field MUST exist and be a string.',
-      function() {
-        for(const proof of proofs) {
-          proof.should.have.property('proofPurpose');
-          proof.proofPurpose.should.be.a('string');
-        }
-      });
+    it('The reason the proof was created ("proof.proofPurpose") MUST be ' +
+        'specified as a string that maps to a URL', async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=The%20reason%20the%20proof%20was%20created%20MUST%20be%20specified%20as%20a%20string%20that%20maps%20to%20a%20URL';
+      for(const proof of proofs) {
+        proof.should.have.property('proofPurpose');
+        proof.proofPurpose.should.be.a('string');
+        await shouldMapToUrl({
+          doc: {
+            '@context': data['@context'],
+            ...proof
+          },
+          term: 'https://w3id.org/security#proofPurpose',
+          prop: '@id'
+        });
+      }
+    });
     it('"proof.proofValue" field MUST exist and be a string.',
       function() {
         for(const proof of proofs) {

--- a/suites/create.js
+++ b/suites/create.js
@@ -5,7 +5,7 @@ import {
   dateRegex, expectedMultibasePrefix,
   isObjectOrArrayOfObjects,
   isStringOrArrayOfStrings, isValidMultibaseEncoded,
-  shouldBeUrl, shouldHaveProof
+  shouldBeUrl, shouldHaveProof, shouldMapToUrl
 } from '../assertions.js';
 import chai from 'chai';
 import {createInitialVc} from '../helpers.js';
@@ -59,11 +59,23 @@ export function runDataIntegrityProofFormatTests({
         }
       }
     });
-    it('"proof.type" field MUST exist and be a string.', function() {
+    it('The specific proof type used for the cryptographic proof MUST be ' +
+        'specified as a string that maps to a URL.', async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=The%20specific%20proof%20type%20used%20for%20the%20cryptographic%20proof%20MUST%20be%20specified%20as%20a%20string%20that%20maps%20to%20a%20URL';
+      const prop = '@type';
       for(const proof of proofs) {
         proof.should.have.property('type');
         proof.type.should.be.a(
           'string', 'Expected "proof.type" to be a string.');
+        const expanded = await jsonld.expand({
+          '@context': data['@context'],
+          type: proof.type
+        });
+        for(const term of expanded) {
+          const types = term[prop];
+          should.exist(types, 'Expected @type to exist.');
+          term[prop].every(url => shouldBeUrl({url, prop}));
+        }
       }
     });
     it(`"proof.type" field MUST be "${expectedProofTypes.join(',')}" ` +


### PR DESCRIPTION
This does not add a new test, but rather uses `jsonld.expand` with a parred down version of the proof to assert on the relevant jsonld expanded form values such as if a value or term maps to a URL.