### PR TITLE
Use credential over vc for create param & remove checks from verificationFail

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -25,16 +25,18 @@ export const shouldBeBase64NoPadUrl = s => BASE_64URL_NOPAD_REGEX.test(s);
 export async function verificationFail({
   credential, verifier, reason, options = {}
 } = {}) {
+  const {settings: {options: verifierOptions}} = verifier;
   const body = {
     verifiableCredential: credential,
     options: {
-      checks: ['proof'],
-      ...options
+      ...options,
+      ...verifierOptions
     }
   };
   const {result, error} = await verifier.post({json: body});
-  should.not.exist(result, 'Expected no result from verifier.');
-  should.exist(error, 'Expected verifier to error.');
+  const withReason = reason || '';
+  should.not.exist(result, 'Expected no result from verifier.' + withReason);
+  should.exist(error, 'Expected verifier to error.' + withReason);
   shouldBeErrorResponse({response: error, reason});
   return {result, error};
 }

--- a/assertions.js
+++ b/assertions.js
@@ -22,6 +22,17 @@ export const shouldBeBs58 = s => bs58.test(s);
 
 export const shouldBeBase64NoPadUrl = s => BASE_64URL_NOPAD_REGEX.test(s);
 
+/**
+ * Posts a VC to a verifier and asserts on the response.
+ *
+ * @param {object} options - Options to use.
+ * @param {object} options.credential - The credential to post.
+ * @param {object} options.verifier - The verifier to post to.
+ * @param {string} [options.reason] - The expected reason for the failure.
+ * @param {object} [options.options] - Request specific options.
+ *
+ * @returns {Promise<object>} The result of the verification.
+ */
 export async function verificationFail({
   credential, verifier, reason, options = {}
 } = {}) {
@@ -29,8 +40,9 @@ export async function verificationFail({
   const body = {
     verifiableCredential: credential,
     options: {
-      ...options,
-      ...verifierOptions
+      ...verifierOptions,
+      // request specific options should over endpoint options
+      ...options
     }
   };
   const {result, error} = await verifier.post({json: body});

--- a/assertions.js
+++ b/assertions.js
@@ -41,7 +41,7 @@ export async function verificationFail({
     verifiableCredential: credential,
     options: {
       ...verifierOptions,
-      // request specific options should over endpoint options
+      // request specific options should overwrite endpoint options
       ...options
     }
   };

--- a/helpers.js
+++ b/helpers.js
@@ -8,22 +8,25 @@ import {v4 as uuidv4} from 'uuid';
  *
  * @param {object} options - Options to use.
  * @param {object} options.issuer - An issuer endpoint.
- * @param {object} options.vc - A vc to be issued.
+ * @param {object} options.credential - A credential to be issued.
  *
  * @throws {Error} Throws if the issuer fails.
  *
  * @returns {Promise<object>} The resulting data from the issuer.
  */
-export const createInitialVc = async ({issuer, vc} = {}) => {
+export async function createInitialVc({issuer, credential} = {}) {
   const {settings: {id: issuerId, options}} = issuer;
-  const body = {credential: structuredClone(vc), options};
+  const _credential = structuredClone(credential);
   // set a fresh id on the credential
-  body.credential.id = `urn:uuid:${uuidv4()}`;
+  _credential.id = `urn:uuid:${uuidv4()}`;
   // use the issuer's id for the issuer property
-  body.credential.issuer = issuerId;
-  const {data, error} = await issuer.post({json: body});
+  _credential.issuer = issuerId;
+  const {data, error} = await issuer.post({json: {
+    credential: _credential,
+    options: {...options}
+  }});
   if(error) {
     throw error;
   }
   return data;
-};
+}

--- a/helpers.js
+++ b/helpers.js
@@ -9,13 +9,14 @@ import {v4 as uuidv4} from 'uuid';
  * @param {object} options - Options to use.
  * @param {object} options.issuer - An issuer endpoint.
  * @param {object} options.credential - A credential to be issued.
+ * @param {object} [options.options] - Request specific options.
  *
  * @throws {Error} Throws if the issuer fails.
  *
  * @returns {Promise<object>} The resulting data from the issuer.
  */
-export async function createInitialVc({issuer, credential} = {}) {
-  const {settings: {id: issuerId, options}} = issuer;
+export async function createInitialVc({issuer, credential, options} = {}) {
+  const {settings: {id: issuerId, options: issuerOptions}} = issuer;
   const _credential = structuredClone(credential);
   // set a fresh id on the credential
   _credential.id = `urn:uuid:${uuidv4()}`;
@@ -23,7 +24,11 @@ export async function createInitialVc({issuer, credential} = {}) {
   _credential.issuer = issuerId;
   const {data, error} = await issuer.post({json: {
     credential: _credential,
-    options: {...options}
+    options: {
+      ...issuerOptions,
+      //request specific options overwrite issuer options
+      ...options
+    }
   }});
   if(error) {
     throw error;

--- a/suites/create.js
+++ b/suites/create.js
@@ -471,7 +471,10 @@ export function runDataIntegrityProofFormatTests({
       let err;
       let data;
       try {
-        data = await createInitialVc({issuer, vc});
+        data = await createInitialVc({
+          issuer,
+          credential: vc
+        });
       } catch(e) {
         err = e;
       }

--- a/suites/create.js
+++ b/suites/create.js
@@ -34,7 +34,7 @@ export function runDataIntegrityProofFormatTests({
       if(!issuer) {
         throw new Error(`Expected ${vendorName} to have an issuer.`);
       }
-      data = await createInitialVc({issuer, vc: validVc});
+      data = await createInitialVc({issuer, credential: validVc});
       proofs = Array.isArray(data.proof) ? data.proof : [data.proof];
     });
     it('When expressing a data integrity proof on an object, a proof ' +


### PR DESCRIPTION
1. remove checks from verificationFail
2. Add reason to verificationFail messages if provided
3. clean up createInitialVc by changing vc param to credential
4. clean up createInitialVc with some minor rearrangements
5. pass endpoint specific options to calls on vc api