### PR TITLE
Suite designers must

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -146,12 +146,15 @@ export async function shouldMapToUrl({doc, term, prop}) {
   }
 }
 
-export function shouldBeVc({vc}) {
-  should.exist(vc, 'Expected VC to exist.');
-  vc.should.be.an('object', 'Expected VC to be an object.');
-  should.exist(vc.type, 'Expected VC to have a type.');
-  isStringOrArrayOfStrings(vc.type).should.equal(
-    true, 'Expected type to be a string or an array of strings');
+export function shouldBeProof({proof}) {
+  should.exist(proof, 'Expected VC to exist.');
+  proof.should.be.an('object', 'Expected proof to be an object.');
+  should.exist(proof.type, 'Expected proof to have a type.');
+  isStringOrArrayOfStrings(proof.type).should.equal(
+    true, 'Expected "proof.type" to be a string or an array of strings');
+  if(proof.id) {
+    shouldBeUrl({url: proof.id, prop: '"proof.id"'});
+  }
 }
 
 /**

--- a/assertions.js
+++ b/assertions.js
@@ -146,15 +146,24 @@ export async function shouldMapToUrl({doc, term, prop}) {
   }
 }
 
+/**
+ * Checks that the proof has all mandatory values.
+ *
+ * @param {object} options - Options to use.
+ * @param {object} options.proof - A DI Proof.
+ */
 export function shouldBeProof({proof}) {
   should.exist(proof, 'Expected VC to exist.');
   proof.should.be.an('object', 'Expected proof to be an object.');
   should.exist(proof.type, 'Expected proof to have a type.');
   isStringOrArrayOfStrings(proof.type).should.equal(
     true, 'Expected "proof.type" to be a string or an array of strings');
-  if(proof.id) {
-    shouldBeUrl({url: proof.id, prop: '"proof.id"'});
-  }
+  should.exist(proof.proofPurpose, 'Expected "proof.proofPurpose" to exist.');
+  proof.proofPurpose.should.be.a(
+    'string', 'Expected "proof.proofPurpose" to be a string.');
+  should.exist(proof.proofValue, 'Expected "proof.proofValue" to exist.');
+  proof.proofValue.should.be.a(
+    'string', 'Expected "proof.proofValue" to be a string.');
 }
 
 /**

--- a/assertions.js
+++ b/assertions.js
@@ -146,6 +146,14 @@ export async function shouldMapToUrl({doc, term, prop}) {
   }
 }
 
+export function shouldBeVc({vc}) {
+  should.exist(vc, 'Expected VC to exist.');
+  vc.should.be.an('object', 'Expected VC to be an object.');
+  should.exist(vc.type, 'Expected VC to have a type.');
+  isStringOrArrayOfStrings(vc.type).should.equal(
+    true, 'Expected type to be a string or an array of strings');
+}
+
 /**
  * Throws an error if a negative test does not return 400 or 422.
  * A reason maybe provided such as "invalid proofValue" etc.

--- a/suites/create.js
+++ b/suites/create.js
@@ -3,9 +3,9 @@
  */
 import {
   dateRegex, expectedMultibasePrefix,
-  isObjectOrArrayOfObjects,
-  isStringOrArrayOfStrings, isValidMultibaseEncoded,
-  shouldBeUrl, shouldHaveProof, shouldMapToUrl
+  isObjectOrArrayOfObjects, isStringOrArrayOfStrings,
+  isValidMultibaseEncoded, shouldBeUrl,
+  shouldHaveProof, shouldMapToUrl, shouldBeVc
 } from '../assertions.js';
 import chai from 'chai';
 import {createInitialVc} from '../helpers.js';
@@ -271,6 +271,12 @@ export function runDataIntegrityProofFormatTests({
           }
         }
       });
+    it('Cryptographic suite designers MUST use mandatory proof value ' +
+    'properties defined in Section 2.1 Proofs, and MAY define other ' +
+    'properties specific to their cryptographic suite.', async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#add-proof:~:text=MUST%20use%20mandatory%20proof%20value%20properties%20defined';
+      shouldBeVc({vc: data});
+    });
     if(cryptosuiteName) {
       it('The value of the cryptosuite property MUST be a string that ' +
         'identifies the cryptographic suite.', async function() {

--- a/suites/create.js
+++ b/suites/create.js
@@ -4,8 +4,8 @@
 import {
   dateRegex, expectedMultibasePrefix,
   isObjectOrArrayOfObjects, isStringOrArrayOfStrings,
-  isValidMultibaseEncoded, shouldBeUrl,
-  shouldHaveProof, shouldMapToUrl, shouldBeVc
+  isValidMultibaseEncoded, shouldBeProof, shouldBeUrl,
+  shouldHaveProof, shouldMapToUrl
 } from '../assertions.js';
 import chai from 'chai';
 import {createInitialVc} from '../helpers.js';
@@ -275,7 +275,9 @@ export function runDataIntegrityProofFormatTests({
     'properties defined in Section 2.1 Proofs, and MAY define other ' +
     'properties specific to their cryptographic suite.', async function() {
       this.test.link = 'https://w3c.github.io/vc-data-integrity/#add-proof:~:text=MUST%20use%20mandatory%20proof%20value%20properties%20defined';
-      shouldBeVc({vc: data});
+      for(const proof of proofs) {
+        shouldBeProof({proof});
+      }
     });
     if(cryptosuiteName) {
       it('The value of the cryptosuite property MUST be a string that ' +


### PR DESCRIPTION
Adds the following test:

Cryptographic suite designers MUST use mandatory proof value properties defined in Section [2.1 Proofs](https://w3c.github.io/vc-data-integrity/#proofs), and MAY define other properties specific to their cryptographic suite.


The assertion only tests for the mandatory proof values at this time.
As time is of the essence this can be expanded to check for stricter conformance in the future.