### PR TITLE
Move credentials generation to before verify tests run.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  */
 import {checkKeyType} from './assertions.js';
 import {createRequire} from 'node:module';
+import {generateTestData} from './vc-generator/index.js';
 import {runDataIntegrityProofFormatTests} from './suites/create.js';
 import {runDataIntegrityProofVerifyTests} from './suites/verify.js';
 
@@ -105,6 +106,14 @@ export function checkDataIntegrityProofVerifyErrors({
     this.rowLabel = 'Test Name';
     this.columnLabel = 'Verifier';
     this.implemented = [];
+    const credentials = {};
+    before(async function() {
+      const data = await generateTestData({...testDataOptions, optionalTests});
+      // this might seem weird, but mocha won't wait for credentials to be set
+      // before passing the credentials var to the tests
+      // so we just update the credentials passed to the actual test suite
+      Object.assign(credentials, data);
+    });
     for(const [vendorName, {endpoints}] of implemented) {
       if(!endpoints) {
         throw new Error(`Expected ${vendorName} to have endpoints.`);
@@ -128,6 +137,7 @@ export function checkDataIntegrityProofVerifyErrors({
           expectedProofType,
           testDescription: name,
           vendorName,
+          credentials,
           testDataOptions,
           optionalTests
         });

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -2,7 +2,6 @@
  * Copyright (c) 2024 Digital Bazaar, Inc.
  */
 import {expect} from 'chai';
-import {generateTestData} from '../vc-generator/index.js';
 import {verificationFail} from '../assertions.js';
 
 export function runDataIntegrityProofVerifyTests({
@@ -10,7 +9,7 @@ export function runDataIntegrityProofVerifyTests({
   expectedProofType,
   testDescription,
   vendorName,
-  testDataOptions,
+  credentials,
   optionalTests
 }) {
   return describe(testDescription, function() {
@@ -27,9 +26,7 @@ export function runDataIntegrityProofVerifyTests({
         rowId: this.currentTest.title
       };
     });
-    let credentials;
     before(async function() {
-      credentials = await generateTestData({...testDataOptions, optionalTests});
       proofValueTests = shouldBeProofValue({credentials, verifier});
     });
     it('Conforming processors MUST produce errors when non-conforming ' +


### PR DESCRIPTION
So we have a slight issue, we are regenerating the verifier test data multiple times.
This moves the verifier test data generation to `index.js` and then passes it to the verifier suite
so that the test data is only generated once per suite test run and not once per implementer.

There might be a better way of handling the before logic, but mocha has some weird rules and it will just go ahead and pass `credentials` to the test function before the before's async function has set the value of credentials so there is a small hack in this PR. I use `Object.assign` to update the properties of the object passed to the verify suite. This works and does not seem to cause any timing issues.