### PR TITLE
JSON-LD term drop

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -39,7 +39,12 @@ export async function verificationFail({
   return {result, error};
 }
 
-export async function issuanceFail({credential, issuer, reason, options = {}}) {
+export async function shouldFailIssuance({
+  credential,
+  issuer,
+  reason,
+  options = {}
+}) {
   const {settings: {id: issuerId, options: issuerOptions}} = issuer;
   credential.issuer = issuerId;
   const body = {

--- a/assertions.js
+++ b/assertions.js
@@ -22,9 +22,9 @@ export const shouldBeBs58 = s => bs58.test(s);
 
 export const shouldBeBase64NoPadUrl = s => BASE_64URL_NOPAD_REGEX.test(s);
 
-export const verificationFail = async ({
+export async function verificationFail({
   credential, verifier, reason, options = {}
-} = {}) => {
+} = {}) {
   const body = {
     verifiableCredential: credential,
     options: {
@@ -36,7 +36,8 @@ export const verificationFail = async ({
   should.not.exist(result, 'Expected no result from verifier.');
   should.exist(error, 'Expected verifier to error.');
   shouldBeErrorResponse({response: error, reason});
-};
+  return {result, error};
+}
 
 export function expectedMultibasePrefix(cryptosuite) {
   const b64urlNoPadSuites = ['ecdsa-sd-2023', 'bbs-2023'];

--- a/assertions.js
+++ b/assertions.js
@@ -52,7 +52,13 @@ export async function issuanceFail({credential, issuer, reason, options = {}}) {
   const {result, error} = await issuer.post({json: body});
   should.not.exist(result, reason || 'Expected no result from issuer.');
   should.exist(error, reason || 'Expected issuer to error.');
-  shouldBeErrorResponse({response: error, reason});
+  shouldBeErrorResponse({
+    response: error,
+    //FIXME remove 500 after informing implementers that issuers must return 400
+    //for invalid credentials
+    expectedStatuses: [400, 422, 500],
+    reason
+  });
   return {result, error};
 }
 

--- a/assertions.js
+++ b/assertions.js
@@ -39,6 +39,23 @@ export async function verificationFail({
   return {result, error};
 }
 
+export async function issuanceFail({credential, issuer, reason, options = {}}) {
+  const {settings: {id: issuerId, options: issuerOptions}} = issuer;
+  credential.issuer = issuerId;
+  const body = {
+    credential,
+    options: {
+      ...issuerOptions,
+      ...options
+    }
+  };
+  const {result, error} = await issuer.post({json: body});
+  should.not.exist(result, reason || 'Expected no result from issuer.');
+  should.exist(error, reason || 'Expected issuer to error.');
+  shouldBeErrorResponse({response: error, reason});
+  return {result, error};
+}
+
 export function expectedMultibasePrefix(cryptosuite) {
   const b64urlNoPadSuites = ['ecdsa-sd-2023', 'bbs-2023'];
 

--- a/suites/create.js
+++ b/suites/create.js
@@ -4,6 +4,7 @@
 import {
   dateRegex, expectedMultibasePrefix,
   isObjectOrArrayOfObjects, isStringOrArrayOfStrings,
+  shouldBeErrorResponse,
   shouldBeProof, shouldBeUrl,
   shouldHaveProof, shouldHaveProofValue, shouldMapToUrl
 } from '../assertions.js';
@@ -280,6 +281,29 @@ export function runDataIntegrityProofFormatTests({
       for(const proof of proofs) {
         shouldBeProof({proof});
       }
+    });
+    it('Implementations that use JSON-LD processing, such as RDF Dataset ' +
+      'Canonicalization [RDF-CANON], MUST throw an error, which SHOULD be ' +
+      'DATA_LOSS_DETECTION_ERROR, when data is dropped by a JSON-LD ' +
+      'processor, such as when an undefined term is detected in an ' +
+      'input document.', async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#securing-data-losslessly:~:text=Implementations%20that%20use%20JSON%2DLD%20processing%2C%20such%20as%20RDF%20Dataset%20Canonicalization%20%5BRDF%2DCANON%5D%2C%20MUST%20throw%20an%20error%2C%20which%20SHOULD%20be%20DATA_LOSS_DETECTION_ERROR%2C%20when%20data%20is%20dropped%20by%20a%20JSON%2DLD%20processor%2C%20such%20as%20when%20an%20undefined%20term%20is%20detected%20in%20an%20input%20document.';
+      let result;
+      let error;
+      const vc = structuredClone(validVc);
+      vc.type.push('InvalidType');
+      try {
+        result = await createInitialVc({issuer, vc});
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(
+        result,
+        'Expected no result from issuer when VC has an undefined type.');
+      shouldBeErrorResponse({
+        response: error,
+        reason: 'Expected issuer to error when VC has an undefined type.'
+      });
     });
     if(cryptosuiteName) {
       it('The value of the cryptosuite property MUST be a string that ' +

--- a/suites/create.js
+++ b/suites/create.js
@@ -4,9 +4,8 @@
 import {
   dateRegex, expectedMultibasePrefix,
   isObjectOrArrayOfObjects, isStringOrArrayOfStrings,
-  issuanceFail,
   shouldBeProof, shouldBeUrl,
-  shouldHaveProof, shouldHaveProofValue, shouldMapToUrl
+  shouldFailIssuance, shouldHaveProof, shouldHaveProofValue, shouldMapToUrl
 } from '../assertions.js';
 import chai from 'chai';
 import {createInitialVc} from '../helpers.js';
@@ -290,14 +289,14 @@ export function runDataIntegrityProofFormatTests({
       this.test.link = 'https://w3c.github.io/vc-data-integrity/#securing-data-losslessly:~:text=Implementations%20that%20use%20JSON%2DLD%20processing%2C%20such%20as%20RDF%20Dataset%20Canonicalization%20%5BRDF%2DCANON%5D%2C%20MUST%20throw%20an%20error%2C%20which%20SHOULD%20be%20DATA_LOSS_DETECTION_ERROR%2C%20when%20data%20is%20dropped%20by%20a%20JSON%2DLD%20processor%2C%20such%20as%20when%20an%20undefined%20term%20is%20detected%20in%20an%20input%20document.';
       const undefinedType = structuredClone(validVc);
       undefinedType.type.push('InvalidType');
-      await issuanceFail({
+      await shouldFailIssuance({
         credential: undefinedType,
         issuer,
         reason: 'Expected issuer to error when VC has an undefined type.'
       });
       const undefinedTerm = structuredClone(validVc);
       undefinedTerm.credentialSubject.invalidTerm = 'invalidTerm';
-      await issuanceFail({
+      await shouldFailIssuance({
         credential: undefinedTerm,
         issuer,
         reason: 'Expected issuer to error when VC has an undefined term.'

--- a/suites/create.js
+++ b/suites/create.js
@@ -4,7 +4,7 @@
 import {
   dateRegex, expectedMultibasePrefix,
   isObjectOrArrayOfObjects, isStringOrArrayOfStrings,
-  shouldBeErrorResponse,
+  issuanceFail,
   shouldBeProof, shouldBeUrl,
   shouldHaveProof, shouldHaveProofValue, shouldMapToUrl
 } from '../assertions.js';
@@ -288,21 +288,19 @@ export function runDataIntegrityProofFormatTests({
       'processor, such as when an undefined term is detected in an ' +
       'input document.', async function() {
       this.test.link = 'https://w3c.github.io/vc-data-integrity/#securing-data-losslessly:~:text=Implementations%20that%20use%20JSON%2DLD%20processing%2C%20such%20as%20RDF%20Dataset%20Canonicalization%20%5BRDF%2DCANON%5D%2C%20MUST%20throw%20an%20error%2C%20which%20SHOULD%20be%20DATA_LOSS_DETECTION_ERROR%2C%20when%20data%20is%20dropped%20by%20a%20JSON%2DLD%20processor%2C%20such%20as%20when%20an%20undefined%20term%20is%20detected%20in%20an%20input%20document.';
-      let result;
-      let error;
-      const vc = structuredClone(validVc);
-      vc.type.push('InvalidType');
-      try {
-        result = await createInitialVc({issuer, vc});
-      } catch(e) {
-        error = e;
-      }
-      should.not.exist(
-        result,
-        'Expected no result from issuer when VC has an undefined type.');
-      shouldBeErrorResponse({
-        response: error,
+      const undefinedType = structuredClone(validVc);
+      undefinedType.type.push('InvalidType');
+      await issuanceFail({
+        credential: undefinedType,
+        issuer,
         reason: 'Expected issuer to error when VC has an undefined type.'
+      });
+      const undefinedTerm = structuredClone(validVc);
+      undefinedTerm.credentialSubject.invalidTerm = 'invalidTerm';
+      await issuanceFail({
+        credential: undefinedTerm,
+        issuer,
+        reason: 'Expected issuer to error when VC has an undefined term.'
       });
     });
     if(cryptosuiteName) {

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -125,12 +125,20 @@ export function runDataIntegrityProofVerifyTests({
         verifier,
         reason: 'Should fail to verify VC when data is dropped by JSON-LD'
       });
-      const credential = credentials.clone('issuedVc');
-      credential.credentialSubject.undefinedTerm = 'IfDroppedWillVerify';
+      const undefinedTerm = credentials.clone('issuedVc');
+      undefinedTerm.credentialSubject.undefinedTerm = 'IfDroppedWillVerify';
       await verificationFail({
-        credential,
+        credential: undefinedTerm,
         verifier,
         reason: 'Should fail to verify VC if an undefined term is added ' +
+          'after issuance.'
+      });
+      const undefinedType = credentials.clone('issuedVc');
+      undefinedType.type.push('UndefinedType');
+      await verificationFail({
+        credential: undefinedType,
+        verifier,
+        reason: 'Should fail to verify VC if an undefined type is added ' +
           'after issuance.'
       });
     });

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -119,6 +119,7 @@ export function runDataIntegrityProofVerifyTests({
       'DATA_LOSS_DETECTION_ERROR, when data is dropped by a JSON-LD ' +
       'processor, such as when an undefined term is detected in an ' +
       'input document.', async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#securing-data-losslessly:~:text=Implementations%20that%20use%20JSON%2DLD%20processing%2C%20such%20as%20RDF%20Dataset%20Canonicalization%20%5BRDF%2DCANON%5D%2C%20MUST%20throw%20an%20error%2C%20which%20SHOULD%20be%20DATA_LOSS_DETECTION_ERROR%2C%20when%20data%20is%20dropped%20by%20a%20JSON%2DLD%20processor%2C%20such%20as%20when%20an%20undefined%20term%20is%20detected%20in%20an%20input%20document.';
       await verificationFail({
         credential: credentials.clone('undefinedTerm'),
         verifier,

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -125,6 +125,14 @@ export function runDataIntegrityProofVerifyTests({
         verifier,
         reason: 'Should fail to verify VC when data is dropped by JSON-LD'
       });
+      const credential = credentials.clone('issuedVc');
+      credential.credentialSubject.undefinedTerm = 'IfDroppedWillVerify';
+      await verificationFail({
+        credential,
+        verifier,
+        reason: 'Should fail to verify VC if an undefined term is added ' +
+          'after issuance.'
+      });
     });
     if(optionalTests?.created) {
       it('The date and time the proof was created is OPTIONAL and, if ' +

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -114,7 +114,17 @@ export function runDataIntegrityProofVerifyTests({
       this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=string%20value%20that%20contains%20the%20base%2Dencoded%20binary%20data%20necessary%20to%20verify%20the%20digital%20proof';
       await proofValueTests;
     });
-
+    it('Implementations that use JSON-LD processing, such as RDF Dataset ' +
+      'Canonicalization [RDF-CANON], MUST throw an error, which SHOULD be ' +
+      'DATA_LOSS_DETECTION_ERROR, when data is dropped by a JSON-LD ' +
+      'processor, such as when an undefined term is detected in an ' +
+      'input document.', async function() {
+      await verificationFail({
+        credential: credentials.clone('undefinedterm'),
+        verifier,
+        reason: 'Should fail to verify VC when data is dropped by JSON-LD'
+      });
+    });
     if(optionalTests?.created) {
       it('The date and time the proof was created is OPTIONAL and, if ' +
       'included, MUST be specified as an [XMLSCHEMA11-2] dateTimeStamp ' +

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -120,7 +120,7 @@ export function runDataIntegrityProofVerifyTests({
       'processor, such as when an undefined term is detected in an ' +
       'input document.', async function() {
       await verificationFail({
-        credential: credentials.clone('undefinedterm'),
+        credential: credentials.clone('undefinedTerm'),
         verifier,
         reason: 'Should fail to verify VC when data is dropped by JSON-LD'
       });

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -19,8 +19,7 @@ describe('Test checkDataIntegrityProofFormat()', function() {
     });
   });
   for(const [suiteName, testDataOptions] of cryptosuites) {
-    describe('should run issuer tests with suite ' +
-      suiteName, async function() {
+    describe('should run issuer tests with suite ', async function() {
       const implemented = new Map();
       before(async function() {
         const key = await getMultiKey({
@@ -32,12 +31,14 @@ describe('Test checkDataIntegrityProofFormat()', function() {
           cryptosuite: testDataOptions.cryptosuite
         });
         const issuer = new MockIssuer({tags, suite, documentLoader});
-        implemented.set(suiteName, issuer);
+        implemented.set(suiteName, {endpoints: [issuer]});
       });
-      checkDataIntegrityProofFormat({
-        implemented,
-        tag,
-        cryptosuiteName: suiteName
+      it(suiteName, function() {
+        checkDataIntegrityProofFormat({
+          implemented,
+          tag,
+          cryptosuiteName: suiteName
+        });
       });
     });
   }

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -2,8 +2,8 @@
  * Copyright (c) 2022 Digital Bazaar, Inc.
  */
 import {checkDataIntegrityProofFormat} from '../index.js';
+import {createSuite} from './helpers.js';
 import {cryptosuites} from './fixtures/constants.js';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 import {documentLoader} from '../vc-generator/documentLoader.js';
 import {getMultiKey} from './fixtures/keys/index.js';
 import {MockIssuer} from './mock-data.js';
@@ -25,11 +25,9 @@ describe('Test checkDataIntegrityProofFormat()', function() {
         const key = await getMultiKey({
           ...testDataOptions
         });
+        const {mandatoryPointers, cryptosuite} = testDataOptions;
         const signer = key.signer();
-        const suite = new DataIntegrityProof({
-          signer,
-          cryptosuite: testDataOptions.cryptosuite
-        });
+        const suite = createSuite({signer, cryptosuite, mandatoryPointers});
         const issuer = new MockIssuer({tags, suite, documentLoader});
         implemented.set(suiteName, {endpoints: [issuer]});
       });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
+ */
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+
+export function createSuite({cryptosuite, signer, mandatoryPointers}) {
+  if(mandatoryPointers) {
+    return new DataIntegrityProof({
+      signer,
+      cryptosuite: cryptosuite.createSignCryptosuite({mandatoryPointers})
+    });
+  }
+  return new DataIntegrityProof({
+    signer,
+    cryptosuite
+  });
+}

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -1,6 +1,7 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc.
  */
+import * as vc from '@digitalbazaar/vc';
 import {createRequire} from 'node:module';
 // FIXME remove this once node has non-experimental support
 // for importing json via import
@@ -9,21 +10,33 @@ const require = createRequire(import.meta.url);
 const issuedVc = require('./fixtures/issuedVc.json');
 
 class MockIssuer {
-  constructor({tags, mockVc}) {
+  constructor({tags, suite, documentLoader}) {
     this._tags = tags;
-    this._mockVc = mockVc;
     this.settings = {
-      id: 'did:issuer:foo',
-      options: {
-
-      }
+      id: 'did:example:issuer',
+      options: {}
     };
+    this.suite = suite;
+    this.documentLoader = documentLoader;
   }
   get tags() {
     return new Set(this._tags);
   }
-  async post() {
-    return {data: this._mockVc};
+  async post({json}) {
+    let data;
+    let error;
+    try {
+      const {credential} = json;
+      data = await vc.issue({
+        credential,
+        documentLoader: this.documentLoader,
+        suite: this.suite,
+      });
+    } catch(e) {
+      error = e;
+    } finally {
+      return {data, error};
+    }
   }
 }
 

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -25,6 +25,7 @@ export class MockIssuer {
   async post({json}) {
     let data;
     let error;
+    let statusCode = 201;
     try {
       const {credential} = json;
       data = await vc.issue({
@@ -35,7 +36,13 @@ export class MockIssuer {
     } catch(e) {
       error = e;
     } finally {
-      return {data, error};
+      if(error) {
+        error.status = 400;
+        statusCode = 400;
+        return {data, error, statusCode};
+      }
+      const result = {data, status: statusCode};
+      return {data, result, statusCode};
     }
   }
 }

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -10,7 +10,12 @@ const require = createRequire(import.meta.url);
 const issuedVc = require('./fixtures/issuedVc.json');
 
 export class MockIssuer {
-  constructor({tags, suite, documentLoader}) {
+  constructor({
+    tags,
+    suite,
+    documentLoader,
+    contexts = ['https://www.w3.org/2018/credentials/v1']
+  }) {
     this._tags = tags;
     this.settings = {
       id: 'did:example:issuer',
@@ -18,6 +23,7 @@ export class MockIssuer {
     };
     this.suite = suite;
     this.documentLoader = documentLoader;
+    this.contexts = contexts;
   }
   get tags() {
     return new Set(this._tags);
@@ -28,6 +34,9 @@ export class MockIssuer {
     let statusCode = 201;
     try {
       const {credential} = json;
+      if(!('@context' in credential)) {
+        credential['@context'] = [...this.contexts];
+      }
       data = await vc.issue({
         credential,
         documentLoader: this.documentLoader,

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -9,7 +9,7 @@ import {createRequire} from 'node:module';
 const require = createRequire(import.meta.url);
 const issuedVc = require('./fixtures/issuedVc.json');
 
-class MockIssuer {
+export class MockIssuer {
   constructor({tags, suite, documentLoader}) {
     this._tags = tags;
     this.settings = {
@@ -61,11 +61,6 @@ class MockVerifier {
   }
 }
 
-const validIssuer = new MockIssuer({
-  tags: ['Test-Issuer', 'Test-Issuer-Valid'],
-  mockVc: structuredClone(issuedVc)
-});
-
 const validVerifier = new MockVerifier({
   tags: ['Test-Verifier', 'Test-Verifier-Valid'],
 });
@@ -81,19 +76,6 @@ invalidVc.proof.proofPurpose = {
 };
 invalidVc.proof.proofValue = 12390;
 
-const invalidIssuer = new MockIssuer({
-  tags: ['Test-Issuer', 'Test-Issuer-Invalid'],
-  mockVc: invalidVc
-});
-
-export const validIssuerImplementations = new Map([
-  ['validIssuerImplementation', {endpoints: [validIssuer]}],
-]);
-
 export const validVerifierImplementations = new Map([
   ['validVerifierImplementation', {endpoints: [validVerifier]}],
-]);
-
-export const invalidIssuerImplementations = new Map([
-  ['invalidIssuerImplementation', {endpoints: [invalidIssuer]}]
 ]);

--- a/vc-generator/contexts.js
+++ b/vc-generator/contexts.js
@@ -30,10 +30,16 @@ const diCtx = _dataIntegrityCtx['@context'];
 // add UnknownProofType to local context for test data
 diCtx.UnknownProofType = structuredClone(diCtx.DataIntegrityProof);
 // add invalidPurpose to context for test data
+// //FIXME this should be in a separate documentLoader
 diCtx.DataIntegrityProof['@context'].proofPurpose['@context'].invalidPurpose = {
   '@id': 'https://w3id.org/security#invalidPurpose',
   '@type': '@id',
   '@container': '@set'
+};
+//FIXME this should be in a separate documentLoader
+diCtx.undefinedTerm = {
+  '@id': 'https://w3id.org/security#undefinedTerm',
+  '@type': 'https://w3id.org/security#termString'
 };
 
 // add contexts for the documentLoader

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -33,6 +33,7 @@ export const generators = {
     invalidProofPurpose,
     invalidProofType,
     invalidVm,
+    undefinedTerm
   },
   // creates a set of shared test vector generators
   // not necessarily used in DI Assertion itself, but used
@@ -76,6 +77,12 @@ function invalidProofPurpose({
   // ensures the proofPurpose matches the term when deriving
   purpose.term = mockPurpose;
   return {...args, suite, selectiveSuite, credential, purpose};
+}
+
+function undefinedTerm({credential, ...args}) {
+  const _credential = structuredClone(credential);
+  _credential.credentialSubject.undefinedTerm = 'undefinedTerm';
+  return {...args, credential: _credential};
 }
 
 // adds an invalid domain
@@ -185,7 +192,6 @@ function invalidProofType({
 function invalidCryptosuite({
   suite,
   selectiveSuite,
-  credential,
   cryptosuiteName = 'UnknownCryptosuite',
   ...args
 }) {
@@ -193,7 +199,7 @@ function invalidCryptosuite({
   if(selectiveSuite) {
     selectiveSuite.cryptosuite = cryptosuiteName;
   }
-  return {...args, suite, selectiveSuite, credential};
+  return {...args, suite, selectiveSuite};
 }
 
 // issues a normal or derived vc


### PR DESCRIPTION
> Implementations that use JSON-LD processing, such as RDF Dataset Canonicalization [[RDF-CANON](https://w3c.github.io/vc-data-integrity/#bib-rdf-canon)], MUST throw an error, which SHOULD be DATA_LOSS_DETECTION_ERROR, when data is dropped by a JSON-LD processor, such as when an undefined term is detected in an input document.

https://w3c.github.io/vc-data-integrity/#securing-data-losslessly:~:text=Implementations%20that%20use%20JSON%2DLD%20processing%2C%20such%20as%20RDF%20Dataset%20Canonicalization%20%5BRDF%2DCANON%5D%2C%20MUST%20throw%20an%20error%2C%20which%20SHOULD%20be%20DATA_LOSS_DETECTION_ERROR%2C%20when%20data%20is%20dropped%20by%20a%20JSON%2DLD%20processor%2C%20such%20as%20when%20an%20undefined%20term%20is%20detected%20in%20an%20input%20document.