### PR TITLE
May accept incorrectly serialized timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - A new parameter `optionalTests` to `checkDataIntegrityProofFormat`.
 - A new parameter `credential` to `checkDataIntegrityProofFormat`.
-- Add a new assertion `verificationSucess` to `assertions`.
+- Add a new assertion `verificationSuccess` to `assertions`.
 
 ## 1.3.1 - 2024-08-07
 

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -158,7 +158,10 @@ export function runDataIntegrityProofVerifyTests({
       const credential = credentials.clone('invalidCryptosuite');
       await verificationFail({credential, verifier});
     });
-    if(optionalTests?.created) {
+    // for backwards compatibility in a minor release we need to support
+    // all 3 optionalTests names for this section
+    const {dates, created, expires} = optionalTests;
+    if(dates || created || expires) {
       it('The date and time the proof was created is OPTIONAL and, if ' +
       'included, MUST be specified as an [XMLSCHEMA11-2] dateTimeStamp ' +
       'string, either in Universal Coordinated Time (UTC), denoted by a Z ' +

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -149,6 +149,15 @@ export function runDataIntegrityProofVerifyTests({
           'after issuance.'
       });
     });
+    it('The value of the cryptosuite property MUST be a string that ' +
+    'identifies the cryptographic suite. If the processing environment ' +
+    'supports subtypes of string, the type of the cryptosuite value MUST ' +
+    'be the https://w3id.org/security#cryptosuiteString subtype of string.',
+    async function() {
+      this.test.link = 'https://w3c.github.io/vc-data-integrity/#introduction:~:text=The%20value%20of%20the%20cryptosuite%20property%20MUST%20be%20a%20string%20that%20identifies%20the%20cryptographic%20suite.%20If%20the%20processing%20environment%20supports%20subtypes%20of%20string%2C%20the%20type%20of%20the%20cryptosuite%20value%20MUST%20be%20the%20https%3A//w3id.org/security%23cryptosuiteString%20subtype%20of%20string.';
+      const credential = credentials.clone('invalidCryptosuite');
+      await verificationFail({credential, verifier});
+    });
     if(optionalTests?.created) {
       it('The date and time the proof was created is OPTIONAL and, if ' +
       'included, MUST be specified as an [XMLSCHEMA11-2] dateTimeStamp ' +
@@ -159,16 +168,25 @@ export function runDataIntegrityProofVerifyTests({
         const credential = credentials.clone('invalidCreated');
         await verificationFail({credential, verifier});
       });
+      // we can't tell if its interpreted correctly but we can ensure their
+      // verifier at least takes timestamps without Z or an offset.
+      it('(created) A conforming processor MAY chose to consume time values ' +
+      'that were incorrectly serialized without an offset.', async function() {
+        this.test.link = 'https://www.w3.org/TR/vc-data-integrity/#proofs:~:text=be%20a%20string.-,created,-The%20date%20and';
+        await verificationSuccess({
+          credential: credentials.clone('noOffsetCreated'),
+          verifier
+        });
+      });
+      it('(expires) A conforming processor MAY chose to consume time values ' +
+      'that were incorrectly serialized without an offset.', async function() {
+        this.test.link = 'https://www.w3.org/TR/vc-data-integrity/#proofs:~:text=interpreted%20as%20UTC.-,expires,-The%20expires%20property';
+        await verificationSuccess({
+          credential: credentials.clone('noOffsetExpires'),
+          verifier
+        });
+      });
     }
-    it('The value of the cryptosuite property MUST be a string that ' +
-    'identifies the cryptographic suite. If the processing environment ' +
-    'supports subtypes of string, the type of the cryptosuite value MUST ' +
-    'be the https://w3id.org/security#cryptosuiteString subtype of string.',
-    async function() {
-      this.test.link = 'https://w3c.github.io/vc-data-integrity/#introduction:~:text=The%20value%20of%20the%20cryptosuite%20property%20MUST%20be%20a%20string%20that%20identifies%20the%20cryptographic%20suite.%20If%20the%20processing%20environment%20supports%20subtypes%20of%20string%2C%20the%20type%20of%20the%20cryptosuite%20value%20MUST%20be%20the%20https%3A//w3id.org/security%23cryptosuiteString%20subtype%20of%20string.';
-      const credential = credentials.clone('invalidCryptosuite');
-      await verificationFail({credential, verifier});
-    });
     if(optionalTests.authentication) {
       it('If options has a non-null domain item, it MUST be equal to ' +
          'proof.domain or an error MUST be raised and SHOULD convey an ' +
@@ -191,24 +209,6 @@ export function runDataIntegrityProofVerifyTests({
             domain: 'domain.example',
             challenge: '1235abcd6789'
           }
-        });
-      });
-      // we can't tell if its interpreted correctly but we can ensure their
-      // verifier at least takes timestamps without Z or an offset.
-      it('(created) A conforming processor MAY chose to consume time values ' +
-      'that were incorrectly serialized without an offset.', async function() {
-        this.test.link = 'https://www.w3.org/TR/vc-data-integrity/#proofs:~:text=be%20a%20string.-,created,-The%20date%20and';
-        await verificationSuccess({
-          credential: credentials.clone('noOffsetCreated'),
-          verifier
-        });
-      });
-      it('(expires) A conforming processor MAY chose to consume time values ' +
-      'that were incorrectly serialized without an offset.', async function() {
-        this.test.link = 'https://www.w3.org/TR/vc-data-integrity/#proofs:~:text=interpreted%20as%20UTC.-,expires,-The%20expires%20property';
-        await verificationSuccess({
-          credential: credentials.clone('noOffsetExpires'),
-          verifier
         });
       });
     }

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -1,8 +1,8 @@
 /*!
  * Copyright (c) 2024 Digital Bazaar, Inc.
  */
+import {verificationFail, verificationSuccess} from '../assertions.js';
 import {expect} from 'chai';
-import {verificationFail} from '../assertions.js';
 
 export function runDataIntegrityProofVerifyTests({
   endpoints,
@@ -198,7 +198,7 @@ export function runDataIntegrityProofVerifyTests({
       it('(created) A conforming processor MAY chose to consume time values ' +
       'that were incorrectly serialized without an offset.', async function() {
         this.test.link = 'https://www.w3.org/TR/vc-data-integrity/#proofs:~:text=be%20a%20string.-,created,-The%20date%20and';
-        await verificationFail({
+        await verificationSuccess({
           credential: credentials.clone('noOffsetCreated'),
           verifier
         });
@@ -206,7 +206,7 @@ export function runDataIntegrityProofVerifyTests({
       it('(expires) A conforming processor MAY chose to consume time values ' +
       'that were incorrectly serialized without an offset.', async function() {
         this.test.link = 'https://www.w3.org/TR/vc-data-integrity/#proofs:~:text=interpreted%20as%20UTC.-,expires,-The%20expires%20property';
-        await verificationFail({
+        await verificationSuccess({
           credential: credentials.clone('noOffsetExpires'),
           verifier
         });

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -165,8 +165,20 @@ export function runDataIntegrityProofVerifyTests({
       'at the end of the value, or with a time zone offset relative ' +
       'to UTC.', async function() {
         this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=MUST%20be%20specified%20as%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%2C%20either%20in%20Universal%20Coordinated%20Time%20(UTC)%2C%20denoted%20by%20a%20Z%20at%20the%20end%20of%20the%20value%2C%20or%20with%20a%20time%20zone%20offset%20relative%20to%20UTC';
-        const credential = credentials.clone('invalidCreated');
-        await verificationFail({credential, verifier});
+        await verificationFail({
+          credential: credentials.clone('invalidCreated'),
+          verifier
+        });
+      });
+      it('If present (expires), it MUST be an [XMLSCHEMA11-2] dateTimeStamp ' +
+      'string, either in Universal Coordinated Time (UTC), denoted by a Z ' +
+      'at the end of the value, or with a time zone offset relative to UTC.',
+      async function() {
+        this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=If%20present%2C%20it%20MUST%20be%20an%20%5BXMLSCHEMA11%2D2%5D%20dateTimeStamp%20string%2C%20either%20in%20Universal%20Coordinated%20Time%20(UTC)%2C%20denoted%20by%20a%20Z%20at%20the%20end%20of%20the%20value%2C%20or%20with%20a%20time%20zone%20offset%20relative%20to%20UTC.';
+        await verificationFail({
+          credential: credentials.clone('invalidExpires'),
+          verifier
+        });
       });
       // we can't tell if its interpreted correctly but we can ensure their
       // verifier at least takes timestamps without Z or an offset.

--- a/tests/fixtures/cryptosuites.js
+++ b/tests/fixtures/cryptosuites.js
@@ -26,7 +26,7 @@ export const cryptosuites = [{
   mandatoryPointers: ['/issuer'],
   selectivePointers: ['/credentialSubject/id'],
   optionalTests: {
-    created: true,
+    dates: true,
     authentication: true
   },
   cryptosuite: ecdsaSd2023Cryptosuite,
@@ -43,7 +43,7 @@ export const cryptosuites = [{
   selectivePointers: ['/credentialSubject/id'],
   optionalTests: {
     //bbs deletes created in order to prevent data leakages
-    created: false,
+    dates: false,
     authentication: true
   },
   cryptosuite: bbs2023Cryptosuite,
@@ -56,7 +56,7 @@ export const cryptosuites = [{
   suiteName: 'ecdsa-rdfc-2019',
   keyType: 'P-256',
   optionalTests: {
-    created: true,
+    dates: true,
     authentication: true
   },
   cryptosuite: ecdsaRdfc2019Cryptosuite,
@@ -68,7 +68,7 @@ export const cryptosuites = [{
   suiteName: 'ecdsa-rdfc-2019',
   keyType: 'P-384',
   optionalTests: {
-    created: true,
+    dates: true,
     authentication: true
   },
   cryptosuite: ecdsaRdfc2019Cryptosuite,
@@ -79,7 +79,7 @@ export const cryptosuites = [{
 }, {
   suiteName: 'eddsa-2022',
   optionalTests: {
-    created: true,
+    dates: true,
     authentication: true
   },
   cryptosuite: eddsa2022CryptoSuite,
@@ -88,7 +88,7 @@ export const cryptosuites = [{
 }, {
   suiteName: 'eddsa-rdfc-2022',
   optionalTests: {
-    created: true,
+    dates: true,
     authentication: true
   },
   cryptosuite: eddsaRdfc2022CryptoSuite,

--- a/tests/mock-data.js
+++ b/tests/mock-data.js
@@ -85,7 +85,7 @@ class MockVerifier {
       ...options
     });
     if(result.verified) {
-      return {data: {...result}, result: {status: 201}, statusCode: 201};
+      return {data: {...result}, result: {status: 200}, statusCode: 200};
     }
     return {data: {...result}, error: {status: 400}, statusCode: 400};
   }

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -11,8 +11,8 @@ const {CredentialIssuancePurpose} = vc;
 
 // generator categories
 export const generators = {
-  // creates test vectors for `proof.created`
-  created: {
+  // creates test vectors for `proof.created` & `proof.expires`
+  dates: {
     noCreated,
     noOffsetCreated,
     noOffsetExpires,
@@ -76,15 +76,17 @@ export const cleanups = {
  * Takes in optionalTests and creates generators for those tests.
  *
  * @param {object} optionalTests - An optionalTests object.
- * @param {boolean} optionalTests.created - Add the created generators?
+ * @param {boolean} optionalTests.created - Add the date generators.
+ * @param {boolean} optionalTests.expires - Add the date generators.
+ * @param {boolean} optionalTests.dates - Add the date generators.
  * @param {boolean} optionalTests.authentication - Add the auth generators?
  *
  * @returns {Map<string, Function>} A map of generators.
  */
-export const getGenerators = ({created, authentication}) => {
+export const getGenerators = ({created, authentication, expires, dates}) => {
   let entries = Object.entries(generators.mandatory);
-  if(created) {
-    entries = entries.concat(Object.entries(generators.created));
+  if(created || expires || dates) {
+    entries = entries.concat(Object.entries(generators.dates));
   }
   if(authentication) {
     entries = entries.concat(Object.entries(generators.authentication));

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -17,6 +17,7 @@ export const generators = {
     noOffsetCreated,
     noOffsetExpires,
     invalidCreated,
+    invalidExpires,
     createdOneYearAgo
   },
   // creates test vectors for Authentication Purpose tests
@@ -173,13 +174,23 @@ function noVerificationMethod({suite, selectiveSuite, credential, ...args}) {
   return {...args, suite, selectiveSuite, credential};
 }
 
-function invalidCreated({suite, selectiveSuite, credential, ...args}) {
+function invalidCreated({suite, selectiveSuite, ...args}) {
   // suite.date will be used as created when signing
   suite.date = 'invalidDate';
   if(selectiveSuite) {
     selectiveSuite.date = 'invalidDate';
   }
-  return {...args, suite, selectiveSuite, credential};
+  return {...args, suite, selectiveSuite};
+}
+
+function invalidExpires({suite, selectiveSuite, ...args}) {
+  suite.proof = suite.proof || {};
+  suite.proof.expires = 'invalidDate';
+  if(selectiveSuite) {
+    selectiveSuite.proof = selectiveSuite.proof || {};
+    selectiveSuite.proof.expires = 'invalidDate';
+  }
+  return {...args, suite, selectiveSuite};
 }
 
 function createdOneYearAgo({
@@ -214,7 +225,8 @@ function invalidProofType({
   suite.type = proofType;
   if(selectiveSuite) {
     const proofId = 'urn:uuid:no-proof-type-test';
-    suite.proof = {id: proofId};
+    suite.proof = suite.proof || {};
+    suite.proof.id = proofId;
     selectiveSuite._cryptosuite.options.proofId = proofId;
     selectiveSuite.type = proofType;
   }
@@ -252,11 +264,13 @@ function noOffsetCreated({suite, selectiveSuite, ...args}) {
 }
 
 function noOffsetExpires({suite, selectiveSuite, ...args}) {
-  const expires = new Date().toISOString().replace(/\.\d+Z$/, '');
   // lop off ms precision from ISO timestamp
-  suite.proof = {expires};
+  const expires = new Date().toISOString().replace(/\.\d+Z$/, '');
+  suite.proof = suite.proof || {};
+  suite.proof.expires = expires;
   if(selectiveSuite) {
-    selectiveSuite.proof = {...suite.proof, ...selectiveSuite.proof};
+    selectiveSuite.proof = selectiveSuite.proof || {};
+    selectiveSuite.proof.expires = expires;
   }
   return {...args, suite, selectiveSuite};
 }


### PR DESCRIPTION
Improvements
1. the MockVerifier returns 200 on success not 201 
2. moves 2 optional date stamp related tests into optionalTests.created
3. moves optionalTests to the bottom of the suite
4. Adds one missing test for `expires` to verify suite