### PR TITLE
In test project do not show keyType undefined.

### DIFF
--- a/tests/20-verifier.js
+++ b/tests/20-verifier.js
@@ -37,7 +37,11 @@ function _runSuite({
   vcVersion, testDataOptions, credential
 }) {
   const {suiteName, keyType} = testDataOptions;
-  return describe(`VC ${vcVersion} Suite ${suiteName} keyType ${keyType}`,
+  let testTitle = `VC ${vcVersion} Suite ${suiteName}`;
+  if(keyType) {
+    testTitle += ` keyType ${keyType}`;
+  }
+  return describe(testTitle,
     async function() {
       before(async function() {
         testDataOptions.testVector = structuredClone(credential);


### PR DESCRIPTION
Corrects a small annoying issue where the test project for this library would print `keyType undefined` for some suites.