### PR TITLE
Add pointers per vc version

### DIFF
--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -22,7 +22,7 @@ describe('Test checkDataIntegrityProofFormat()', function() {
 
 describe('should issue all suites', function() {
   for(const testDataOptions of cryptosuites) {
-    for(const [vcVersion, credential] of versionedCredentials) {
+    for(const [vcVersion, {credential}] of versionedCredentials) {
       _runSuite({
         vcVersion,
         testDataOptions,

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -22,24 +22,34 @@ describe('Test checkDataIntegrityProofFormat()', function() {
 
 describe('should issue all suites', function() {
   for(const testDataOptions of cryptosuites) {
-    for(const [vcVersion, {credential}] of versionedCredentials) {
+    for(const [
+      vcVersion,
+      {credential, mandatoryPointers}
+    ] of versionedCredentials) {
       _runSuite({
         vcVersion,
         testDataOptions,
-        credential
+        credential,
+        mandatoryPointers
       });
     }
   }
 });
 
-function _runSuite({vcVersion, testDataOptions, credential}) {
+function _runSuite({
+  vcVersion, testDataOptions,
+  credential, mandatoryPointers
+}) {
   const {suiteName, keyType = ''} = testDataOptions;
   return describe(`VC ${vcVersion} Suite ${suiteName} keyType ${keyType}`,
     function() {
       const implemented = new Map();
-      const {mandatoryPointers, cryptosuite, key} = testDataOptions;
+      const {cryptosuite, key, derived} = testDataOptions;
       const signer = key.signer();
-      const suite = createSuite({signer, cryptosuite, mandatoryPointers});
+      const suite = createSuite({
+        signer, cryptosuite,
+        mandatoryPointers, derived
+      });
       // pass the VC's context to the issuer
       const {'@context': contexts} = credential;
       const issuer = new MockIssuer({

--- a/tests/20-verifier.js
+++ b/tests/20-verifier.js
@@ -23,20 +23,27 @@ describe('Test checkDataIntegrityProofVerifyErrors()', function() {
 
 describe('should verify all suites', function() {
   for(const testDataOptions of cryptosuites) {
-    for(const [vcVersion, {credential}] of versionedCredentials) {
+    for(const [
+      vcVersion,
+      {credential, mandatoryPointers, selectivePointers}
+    ] of versionedCredentials) {
       _runSuite({
         vcVersion,
         testDataOptions,
-        credential
+        credential,
+        mandatoryPointers,
+        selectivePointers
       });
     }
   }
 });
 
 function _runSuite({
-  vcVersion, testDataOptions, credential
+  vcVersion, testDataOptions,
+  credential, mandatoryPointers,
+  selectivePointers
 }) {
-  const {suiteName, keyType} = testDataOptions;
+  const {suiteName, keyType, derived} = testDataOptions;
   let testTitle = `VC ${vcVersion} Suite ${suiteName}`;
   if(keyType) {
     testTitle += ` keyType ${keyType}`;
@@ -46,6 +53,10 @@ function _runSuite({
       before(async function() {
         testDataOptions.testVector = structuredClone(credential);
         testDataOptions.documentLoader = documentLoader;
+        if(derived) {
+          testDataOptions.mandatoryPointers = mandatoryPointers;
+          testDataOptions.selectivePointers = selectivePointers;
+        }
       });
       checkDataIntegrityProofVerifyErrors({
         implemented: validVerifierImplementations,

--- a/tests/20-verifier.js
+++ b/tests/20-verifier.js
@@ -23,7 +23,7 @@ describe('Test checkDataIntegrityProofVerifyErrors()', function() {
 
 describe('should verify all suites', function() {
   for(const testDataOptions of cryptosuites) {
-    for(const [vcVersion, credential] of versionedCredentials) {
+    for(const [vcVersion, {credential}] of versionedCredentials) {
       _runSuite({
         vcVersion,
         testDataOptions,

--- a/tests/fixtures/credentials/dl-v1.json
+++ b/tests/fixtures/credentials/dl-v1.json
@@ -1,38 +1,40 @@
 {
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    {
-      "@protected": true,
-      "DriverLicenseCredential": "urn:example:DriverLicenseCredential",
-      "DriverLicense": {
-        "@id": "urn:example:DriverLicense",
-        "@context": {
-          "@protected": true,
-          "id": "@id",
-          "type": "@type",
-          "documentIdentifier": "urn:example:documentIdentifier",
-          "dateOfBirth": "urn:example:dateOfBirth",
-          "expirationDate": "urn:example:expiration",
-          "issuingAuthority": "urn:example:issuingAuthority"
+  "credential": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      {
+        "@protected": true,
+        "DriverLicenseCredential": "urn:example:DriverLicenseCredential",
+        "DriverLicense": {
+          "@id": "urn:example:DriverLicense",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "documentIdentifier": "urn:example:documentIdentifier",
+            "dateOfBirth": "urn:example:dateOfBirth",
+            "expirationDate": "urn:example:expiration",
+            "issuingAuthority": "urn:example:issuingAuthority"
+          }
+        },
+        "driverLicense": {
+          "@id": "urn:example:driverLicense",
+          "@type": "@id"
         }
-      },
-      "driverLicense": {
-        "@id": "urn:example:driverLicense",
-        "@type": "@id"
       }
-    }
-  ],
-  "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
-  "type": ["VerifiableCredential", "DriverLicenseCredential"],
-  "issuanceDate": "2020-03-16T22:37:26.544Z",
-  "credentialSubject": {
-    "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
-    "driverLicense": {
-      "type": "DriverLicense",
-      "documentIdentifier": "T21387yc328c7y32h23f23",
-      "dateOfBirth": "01-01-1990",
-      "expirationDate": "01-01-2030",
-      "issuingAuthority": "VA"
+    ],
+    "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69757",
+    "type": ["VerifiableCredential", "DriverLicenseCredential"],
+    "issuanceDate": "2020-03-16T22:37:26.544Z",
+    "credentialSubject": {
+      "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
+      "driverLicense": {
+        "type": "DriverLicense",
+        "documentIdentifier": "T21387yc328c7y32h23f23",
+        "dateOfBirth": "01-01-1990",
+        "expirationDate": "01-01-2030",
+        "issuingAuthority": "VA"
+      }
     }
   }
 }

--- a/tests/fixtures/credentials/dl-v1.json
+++ b/tests/fixtures/credentials/dl-v1.json
@@ -36,5 +36,7 @@
         "issuingAuthority": "VA"
       }
     }
-  }
+  },
+  "mandatoryPointers": ["/issuer", "issuanceDate"],
+  "selectivePointers": ["/credentialSubject/driverLicense/documentIdentifier"]
 }

--- a/tests/fixtures/credentials/dl-v2.json
+++ b/tests/fixtures/credentials/dl-v2.json
@@ -35,5 +35,7 @@
         "issuingAuthority": "VA"
       }
     }
-  }
+  },
+  "mandatoryPointers": ["/issuer"],
+  "selectivePointers": ["/credentialSubject/driverLicense/documentIdentifier"]
 }

--- a/tests/fixtures/credentials/dl-v2.json
+++ b/tests/fixtures/credentials/dl-v2.json
@@ -1,37 +1,39 @@
 {
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    {
-      "@protected": true,
-      "DriverLicenseCredential": "urn:example:DriverLicenseCredential",
-      "DriverLicense": {
-        "@id": "urn:example:DriverLicense",
-        "@context": {
-          "@protected": true,
-          "id": "@id",
-          "type": "@type",
-          "documentIdentifier": "urn:example:documentIdentifier",
-          "dateOfBirth": "urn:example:dateOfBirth",
-          "expirationDate": "urn:example:expiration",
-          "issuingAuthority": "urn:example:issuingAuthority"
+  "credential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      {
+        "@protected": true,
+        "DriverLicenseCredential": "urn:example:DriverLicenseCredential",
+        "DriverLicense": {
+          "@id": "urn:example:DriverLicense",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "documentIdentifier": "urn:example:documentIdentifier",
+            "dateOfBirth": "urn:example:dateOfBirth",
+            "expirationDate": "urn:example:expiration",
+            "issuingAuthority": "urn:example:issuingAuthority"
+          }
+        },
+        "driverLicense": {
+          "@id": "urn:example:driverLicense",
+          "@type": "@id"
         }
-      },
-      "driverLicense": {
-        "@id": "urn:example:driverLicense",
-        "@type": "@id"
       }
-    }
-  ],
-  "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69758",
-  "type": ["VerifiableCredential", "DriverLicenseCredential"],
-  "credentialSubject": {
-    "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
-    "driverLicense": {
-      "type": "DriverLicense",
-      "documentIdentifier": "T21387yc328c7y32h23f23",
-      "dateOfBirth": "01-01-1990",
-      "expirationDate": "01-01-2030",
-      "issuingAuthority": "VA"
+    ],
+    "id": "urn:uuid:36245ee9-9074-4b05-a777-febff2e69758",
+    "type": ["VerifiableCredential", "DriverLicenseCredential"],
+    "credentialSubject": {
+      "id": "urn:uuid:1a0e4ef5-091f-4060-842e-18e519ab9440",
+      "driverLicense": {
+        "type": "DriverLicense",
+        "documentIdentifier": "T21387yc328c7y32h23f23",
+        "dateOfBirth": "01-01-1990",
+        "expirationDate": "01-01-2030",
+        "issuingAuthority": "VA"
+      }
     }
   }
 }

--- a/tests/fixtures/cryptosuites.js
+++ b/tests/fixtures/cryptosuites.js
@@ -106,12 +106,11 @@ for(const suite of cryptosuites) {
 
 export const verifierSuites = cryptosuites.map(({
   cryptosuite,
-  mandatoryPointers,
   derived
 }) => {
   if(derived) {
     return new DataIntegrityProof({
-      cryptosuite: cryptosuite.createVerifyCryptosuite({mandatoryPointers})
+      cryptosuite: cryptosuite.createVerifyCryptosuite()
     });
   }
   return new DataIntegrityProof({

--- a/tests/fixtures/cryptosuites.js
+++ b/tests/fixtures/cryptosuites.js
@@ -23,8 +23,6 @@ export const cryptosuites = [{
   suiteName: 'ecdsa-sd-2023',
   keyType: 'P-256',
   derived: true,
-  mandatoryPointers: ['/issuer'],
-  selectivePointers: ['/credentialSubject/id'],
   optionalTests: {
     dates: true,
     authentication: true
@@ -39,8 +37,6 @@ export const cryptosuites = [{
   suiteName: 'bbs-2023',
   keyType: 'Bls12381G2',
   derived: true,
-  mandatoryPointers: ['/issuer'],
-  selectivePointers: ['/credentialSubject/id'],
   optionalTests: {
     //bbs deletes created in order to prevent data leakages
     dates: false,

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -3,8 +3,11 @@
  */
 import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
 
-export function createSuite({cryptosuite, signer, mandatoryPointers}) {
-  if(mandatoryPointers) {
+export function createSuite({
+  cryptosuite, signer,
+  mandatoryPointers, derived = false
+}) {
+  if(derived) {
     return new DataIntegrityProof({
       signer,
       cryptosuite: cryptosuite.createSignCryptosuite({mandatoryPointers})


### PR DESCRIPTION
Updates the test project to work more like the actual suites where mandatoryPointers and selectivePointers are credential and VC version specific.

- also fixes a small issue where mandatoryPointers was being passed to `createVerifier` for sd/bbs verifiers.