### PR TITLE
Remove selectivePointers monkeyPatch from undefinedTerm generator.

### DIFF
--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -264,14 +264,10 @@ function invalidProofPurpose({
   return {...args, suite, selectiveSuite, credential, purpose};
 }
 
-function undefinedTerm({credential, selectiveSuite, ...args}) {
+function undefinedTerm({credential, ...args}) {
   const _credential = structuredClone(credential);
   _credential.credentialSubject.undefinedTerm = 'undefinedTerm';
-  if(selectiveSuite) {
-    selectiveSuite?._cryptosuite?.options?.selectivePointers.push(
-      '/credentialSubject/undefinedTerm');
-  }
-  return {...args, credential: _credential, selectiveSuite};
+  return {...args, credential: _credential};
 }
 
 // adds an invalid domain


### PR DESCRIPTION
Small PATCH, removes a piece of monkey patch code that has a more elegant solution now.

Related to: https://github.com/w3c-ccg/data-integrity-test-suite-assertion/issues/56