### PR TITLE
Remove last deprecated statements

### DIFF
--- a/suites/verify.js
+++ b/suites/verify.js
@@ -1,8 +1,11 @@
 /*!
  * Copyright (c) 2024 Digital Bazaar, Inc.
  */
-import {verificationFail, verificationSuccess} from '../assertions.js';
-import {expect} from 'chai';
+import {
+  shouldBeProofValue,
+  verificationFail,
+  verificationSuccess
+} from '../assertions.js';
 
 export function runDataIntegrityProofVerifyTests({
   endpoints,
@@ -309,37 +312,5 @@ export function runDataIntegrityProofVerifyTests({
 
       });
     }
-  });
-}
-
-async function shouldBeProofValue({credentials, verifier}) {
-  expect(credentials, 'Expected test data to be generated.').to.exist;
-  expect(credentials.clone('issuedVc'), 'Expected a valid Vc to be issued.').
-    to.exist;
-  // proofValue is added after signing so we can
-  // safely delete it for this test
-  const noProofValue = credentials.clone('issuedVc');
-  delete noProofValue.proof.proofValue;
-  await verificationFail({
-    credential: noProofValue,
-    verifier,
-    reason: 'MUST not verify VC with no "proofValue".'
-  });
-  // null should be an invalid proofValue for almost any proof
-  const nullProofValue = credentials.clone('issuedVc');
-  nullProofValue.proof.proofValue = null;
-  await verificationFail({
-    credential: nullProofValue,
-    verifier,
-    reason: 'MUST not verify VC with "proofValue" null.'
-  });
-  const noProofValueHeader = credentials.clone('issuedVc');
-  // Remove the multibase header to cause validation error
-  noProofValueHeader.proof.proofValue = noProofValueHeader.proof.proofValue.
-    slice(1);
-  await verificationFail({
-    credential: noProofValueHeader,
-    verifier,
-    reason: 'MUST not verify VC with invalid multibase header on "proofValue"'
   });
 }

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -104,12 +104,32 @@ export function runDataIntegrityProofVerifyTests({
         reason: 'MUST not verify VC w/o "proof.proofPurpose"'
       });
     });
-    it(`If the "proof.type" field is not the string ` +
-      `"${expectedProofType}", an error MUST be raised.`,
-    async function() {
-      const credential = credentials.clone('invalidProofType');
-      await verificationFail({credential, verifier});
-    });
+    // use updated statement for DataIntegrityProof tests
+    if(expectedProofType === 'DataIntegrityProof') {
+      it('The type property MUST contain the string DataIntegrityProof.',
+        async function() {
+          this.test.link = 'https://w3c.github.io/vc-data-integrity/#proofs:~:text=The%20type%20property%20MUST%20contain%20the%20string%20DataIntegrityProof.';
+          const credential = credentials.clone('invalidProofType');
+          await verificationFail({
+            credential,
+            verifier,
+            reason: 'Should not verify VC with invalid "proof.type"'
+          });
+        });
+    } else {
+      // if the expectedProofType if Ed25519Sig etc. use the
+      // deprecated statement
+      it(`If the "proof.type" field is not the string ` +
+        `"${expectedProofType}", an error MUST be raised.`,
+      async function() {
+        const credential = credentials.clone('invalidProofType');
+        await verificationFail({
+          credential,
+          verifier,
+          reason: 'Should not verify VC with invalid "proof.type"'
+        });
+      });
+    }
     it('If the "proof.verificationMethod" field is invalid, an error ' +
       'MUST be raised.', async function() {
       const credential = credentials.clone('invalidVm');

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -130,11 +130,6 @@ export function runDataIntegrityProofVerifyTests({
         });
       });
     }
-    it('If the "proof.proofPurpose" field is invalid, an error MUST ' +
-      'be raised.', async function() {
-      const credential = credentials.clone('invalidProofPurpose');
-      await verificationFail({credential, verifier});
-    });
     it('If expectedProofPurpose was given, and it does not match ' +
         'proof.proofPurpose, an error MUST be raised and SHOULD convey an ' +
         'error type of PROOF_VERIFICATION_ERROR.', async function() {

--- a/suites/verify.js
+++ b/suites/verify.js
@@ -130,11 +130,6 @@ export function runDataIntegrityProofVerifyTests({
         });
       });
     }
-    it('If the "proof.verificationMethod" field is invalid, an error ' +
-      'MUST be raised.', async function() {
-      const credential = credentials.clone('invalidVm');
-      await verificationFail({credential, verifier});
-    });
     it('If the "proof.proofPurpose" field is invalid, an error MUST ' +
       'be raised.', async function() {
       const credential = credentials.clone('invalidProofPurpose');

--- a/vc-generator/generators.js
+++ b/vc-generator/generators.js
@@ -308,6 +308,7 @@ function invalidVm({
   suite,
   selectiveSuite,
   credential,
+  //FIXME this generator should support non-string verificationMethods
   mockVM = 'did:key:invalidVm',
   ...args
 }) {


### PR DESCRIPTION
Features:

1. Renames the invalid proof type to match current spec text
2. Removes deprecated verificationMethod test as verificationMethod is now OPTIONAL
3. Removes deprecated proofPurpose tests as newer test was already using generator for it
4. small clean up in the verify suite.