### PR TITLE
Fix documentLoader variable name when passing to derive function

### DIFF
--- a/vc-generator/issuer.js
+++ b/vc-generator/issuer.js
@@ -41,7 +41,7 @@ export async function issueCloned({
   }
   return deriveCloned({
     verifiableCredential,
-    documentLoader: loader,
+    loader,
     purpose,
     selectiveSuite
   });


### PR DESCRIPTION
Should fix context issues we have been experiencing, the document loader class wasn't being passed properly and was getting overwritten.